### PR TITLE
support intermediate flushes when encoding

### DIFF
--- a/src/codec/flate/encoder.rs
+++ b/src/codec/flate/encoder.rs
@@ -67,18 +67,6 @@ impl Encode for FlateEncoder {
             FlushCompress::Sync,
         )?;
 
-        loop {
-            let old_len = output.written().len();
-            self.encode(
-                &mut PartialBuffer::new(&[][..]),
-                output,
-                FlushCompress::None,
-            )?;
-            if output.written().len() == old_len {
-                break;
-            }
-        }
-
         self.flushed = true;
         Ok(!output.unwritten().is_empty())
     }


### PR DESCRIPTION
*disclaimer: this is an attempt at fixing https://github.com/apollographql/router/issues/1572, for which I'm under tight timing constraints, so right now this PR's goal is discussing and finding a quick fix that we can use directly in the router, and then I'll help find a proper solution.*

tentative fix for #154

Here I make sure to call the `flush` method on pending, but what happens here is that one 64 bytes chunk of compressed data is returned immediately (not enough for the first part of the encoded data), and then it waits for 5s for the rest. Any advice on making it work? Does it need to flush multiple times?