### PR TITLE
Bump zstd-safe from 5.0.1+zstd.1.5.2 to 6.0.3+zstd.1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,18 +888,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.1+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.1+zstd.1.5.2"
+version = "6.0.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
+checksum = "68e4a3f57d13d0ab7e478665c60f35e2a613dcd527851c2c7287ce5c787e134a"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ flate2 = { version = "1.0.11", optional = true }
 futures-core = { version = "0.3.0", default-features = false }
 futures-io = { version = "0.3.0", default-features = false, features = ["std"], optional = true }
 pin-project-lite = "0.2.0"
-libzstd = { package = "zstd", version = "0.11.1", optional = true, default-features = false }
-zstd-safe = { version = "5.0.1", optional = true, default-features = false }
+libzstd = { package = "zstd", version = "0.12.3", optional = true, default-features = false }
+zstd-safe = { version = "6.0.3", optional = true, default-features = false }
 memchr = "2.2.1"
 tokio-02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 tokio-03 = { package = "tokio", version = "0.3.0", optional = true, default-features = false }


### PR DESCRIPTION
This is #184 but with the `zstd` dependency updated as well to resolve the build error.