### PR TITLE
use automatic doc cfg for features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 )]
 //!
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(
     missing_docs,
     rust_2018_idioms,
@@ -135,10 +135,8 @@ mod macros;
 mod codec;
 
 #[cfg(feature = "futures-io")]
-#[cfg_attr(docsrs, doc(cfg(feature = "futures-io")))]
 pub mod futures;
 #[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio;
 
 mod unshared;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,20 +1,18 @@
 macro_rules! algos {
     (@algo $algo:ident [$algo_s:expr] $decoder:ident $encoder:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
-        #[cfg(feature = $algo_s)]
         decoder! {
             /// A
             #[doc = $algo_s]
             /// decoder, or decompressor.
-            #[cfg_attr(docsrs, doc(cfg(feature = $algo_s)))]
+            #[cfg(feature = $algo_s)]
             $decoder
         }
 
-        #[cfg(feature = $algo_s)]
         encoder! {
             /// A
-            #[doc = $algo_s]
             /// encoder, or compressor.
-            #[cfg_attr(docsrs, doc(cfg(feature = $algo_s)))]
+            #[doc = $algo_s]
+            #[cfg(feature = $algo_s)]
             $encoder<$inner> {
                 pub fn new(inner: $inner) -> Self {
                     Self::with_quality(inner, crate::Level::Default)


### PR DESCRIPTION
`doc_auto_cfg` is in a good enough state now. Also fixes some attribute positions so that feature combinations get shown correctly.

![2023-05-06_19 21 13-4d1eefb6](https://user-images.githubusercontent.com/3316789/236640641-61bdcfcb-fb13-4e85-8e1b-30f51fe1f61e.png)

blocked on #152