### PR TITLE
refactor: use concat in doc comments

### DIFF
--- a/src/futures/bufread/macros/decoder.rs
+++ b/src/futures/bufread/macros/decoder.rs
@@ -2,10 +2,10 @@ macro_rules! decoder {
     ($(#[$attr:meta])* $name:ident) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncRead`](futures_io::AsyncRead) interface and will
             /// read compressed data from an underlying stream and emit a stream of uncompressed data.
+            #[derive(Debug)]
             pub struct $name<R> {
                 #[pin]
                 inner: crate::futures::bufread::Decoder<R, crate::codec::$name>,

--- a/src/futures/bufread/macros/encoder.rs
+++ b/src/futures/bufread/macros/encoder.rs
@@ -2,10 +2,10 @@ macro_rules! encoder {
     ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncRead`](futures_io::AsyncRead) interface and will
             /// read uncompressed data from an underlying stream and emit a stream of compressed data.
+            #[derive(Debug)]
             pub struct $name<$inner> {
                 #[pin]
                 inner: crate::futures::bufread::Encoder<$inner, crate::codec::$name>,

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,4 +1,4 @@
-//! Implementations for IO traits exported by `futures`.
+//! Implementations for IO traits exported by [`futures-io`](::futures_io).
 
 pub mod bufread;
 pub mod write;

--- a/src/futures/write/macros/decoder.rs
+++ b/src/futures/write/macros/decoder.rs
@@ -2,10 +2,10 @@ macro_rules! decoder {
     ($(#[$attr:meta])* $name:ident) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncWrite`](futures_io::AsyncWrite) interface and will
             /// take in compressed data and write it uncompressed to an underlying stream.
+            #[derive(Debug)]
             pub struct $name<W> {
                 #[pin]
                 inner: crate::futures::write::Decoder<W, crate::codec::$name>,
@@ -13,7 +13,7 @@ macro_rules! decoder {
         }
 
         impl<W: futures_io::AsyncWrite> $name<W> {
-            /// Creates a new decoder which will take in compressed data and write it uncompressedd
+            /// Creates a new decoder which will take in compressed data and write it uncompressed
             /// to the given stream.
             pub fn new(read: W) -> $name<W> {
                 $name {

--- a/src/futures/write/macros/encoder.rs
+++ b/src/futures/write/macros/encoder.rs
@@ -2,10 +2,10 @@ macro_rules! encoder {
     ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncWrite`](futures_io::AsyncWrite) interface and will
             /// take in uncompressed data and write it compressed to an underlying stream.
+            #[derive(Debug)]
             pub struct $name<$inner> {
                 #[pin]
                 inner: crate::futures::write::Encoder<$inner, crate::codec::$name>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,17 +1,15 @@
 macro_rules! algos {
     (@algo $algo:ident [$algo_s:expr] $decoder:ident $encoder:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
+        #[cfg(feature = $algo_s)]
         decoder! {
-            /// A
-            #[doc = $algo_s]
-            /// decoder, or decompressor.
+            #[doc = concat!("A ", $algo_s, " decoder, or decompressor")]
             #[cfg(feature = $algo_s)]
             $decoder
         }
 
+        #[cfg(feature = $algo_s)]
         encoder! {
-            /// A
-            /// encoder, or compressor.
-            #[doc = $algo_s]
+            #[doc = concat!("A ", $algo_s, " encoder, or compressor.")]
             #[cfg(feature = $algo_s)]
             $encoder<$inner> {
                 pub fn new(inner: $inner) -> Self {

--- a/src/tokio/bufread/macros/decoder.rs
+++ b/src/tokio/bufread/macros/decoder.rs
@@ -2,10 +2,10 @@ macro_rules! decoder {
     ($(#[$attr:meta])* $name:ident) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncRead`](tokio::io::AsyncRead) interface and will
             /// read compressed data from an underlying stream and emit a stream of uncompressed data.
+            #[derive(Debug)]
             pub struct $name<R> {
                 #[pin]
                 inner: crate::tokio::bufread::Decoder<R, crate::codec::$name>,

--- a/src/tokio/bufread/macros/encoder.rs
+++ b/src/tokio/bufread/macros/encoder.rs
@@ -2,10 +2,10 @@ macro_rules! encoder {
     ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncRead`](tokio::io::AsyncRead) interface and will
             /// read uncompressed data from an underlying stream and emit a stream of compressed data.
+            #[derive(Debug)]
             pub struct $name<$inner> {
                 #[pin]
                 inner: crate::tokio::bufread::Encoder<$inner, crate::codec::$name>,

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -1,4 +1,4 @@
-//! Implementations for IO traits exported by [`tokio` v1.0](::tokio).
+//! Implementations for IO traits exported by [`tokio` v1.x](::tokio).
 
 pub mod bufread;
 pub mod write;

--- a/src/tokio/write/macros/decoder.rs
+++ b/src/tokio/write/macros/decoder.rs
@@ -2,10 +2,10 @@ macro_rules! decoder {
     ($(#[$attr:meta])* $name:ident) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncWrite`](tokio::io::AsyncWrite) interface and will
             /// take in compressed data and write it uncompressed to an underlying stream.
+            #[derive(Debug)]
             pub struct $name<W> {
                 #[pin]
                 inner: crate::tokio::write::Decoder<W, crate::codec::$name>,
@@ -13,7 +13,7 @@ macro_rules! decoder {
         }
 
         impl<W: tokio::io::AsyncWrite> $name<W> {
-            /// Creates a new decoder which will take in compressed data and write it uncompressedd
+            /// Creates a new decoder which will take in compressed data and write it uncompressed
             /// to the given stream.
             pub fn new(read: W) -> $name<W> {
                 $name {

--- a/src/tokio/write/macros/encoder.rs
+++ b/src/tokio/write/macros/encoder.rs
@@ -2,10 +2,10 @@ macro_rules! encoder {
     ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
         pin_project_lite::pin_project! {
             $(#[$attr])*
-            #[derive(Debug)]
             ///
             /// This structure implements an [`AsyncWrite`](tokio::io::AsyncWrite) interface and will
             /// take in uncompressed data and write it compressed to an underlying stream.
+            #[derive(Debug)]
             pub struct $name<$inner> {
                 #[pin]
                 inner: crate::tokio::write::Encoder<$inner, crate::codec::$name>,


### PR DESCRIPTION
also fixes build when some features are not enabled (for some reason not picked up by exhaustive feature powerset check)