### PR TITLE
Speedup ci

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -2,6 +2,8 @@ name: base
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test:
@@ -10,7 +12,23 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - run: cargo --locked test --workspace --all-features
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+    - run: |
+        cargo nextest run --locked --workspace --all-features
+        cargo test --locked --workspace --doc --all-features
 
 on:
   merge_group:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,8 @@ name: coverage
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   codecov:
@@ -12,6 +14,17 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: taiki-e/cache-cargo-install-action@v1
       with: { tool: cargo-tarpaulin }
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run: cargo --locked tarpaulin --all-features -- --skip 'proptest::'
     - uses: codecov/codecov-action@v3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   docsrs:
@@ -14,6 +16,17 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run: cargo doc --all-features --no-deps
 
 on:

--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -2,6 +2,8 @@ name: exhaustive
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test:
@@ -21,13 +23,30 @@ jobs:
       with:
         toolchain: ${{ matrix.platform.toolchain }}
         target: ${{ matrix.platform.target }}
-    - run: cargo --locked test --all --all-features
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+    - run: |
+        cargo nextest run --locked --workspace --all-features
+        cargo test --locked --workspace --doc --all-features
 
   min-versions:
     name: cargo test --shallow-minimal-versions
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: { toolchain: nightly }
     - name: Update to shallow minimal versions
@@ -47,7 +66,23 @@ jobs:
         ) -Z minimal-versions
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: { toolchain: stable }
-    - run: cargo --locked test --workspace --all-features
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+    - run: |
+        cargo nextest run --locked --workspace --all-features
+        cargo test --locked --workspace --doc --all-features
 
   check-features:
     name: cargo hack check --feature-powerset
@@ -59,6 +94,17 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: taiki-e/cache-cargo-install-action@v1
       with: { tool: cargo-hack }
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run:
         cargo hack check
           --workspace
@@ -76,6 +122,17 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: taiki-e/cache-cargo-install-action@v1
       with: { tool: cargo-hack }
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run:
         cargo hack check
           --workspace

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: lint
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   fmt:
@@ -11,6 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: { components: rustfmt }
+
     - run: cargo fmt --all -- --check
 
   clippy:
@@ -20,6 +23,17 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: { components: clippy }
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run: cargo --locked clippy --all --all-targets --all-features -- -D warnings
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,8 @@ name: nightly
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test:
@@ -12,7 +14,23 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
-    - run: cargo --locked test --all --all-features
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+    - run: |
+        cargo nextest run --locked --workspace --all-features
+        cargo test --locked --workspace --doc --all-features
 
   fmt:
     name: cargo +nightly fmt --check
@@ -23,6 +41,7 @@ jobs:
       with:
         toolchain: nightly
         components: rustfmt
+
     - run: cargo fmt --all -- --check
 
   clippy:
@@ -34,6 +53,17 @@ jobs:
       with:
         toolchain: nightly
         components: clippy
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-index-
+
     - run: cargo --locked clippy --all --all-targets --all-features -- -D warnings
 
 on:


### PR DESCRIPTION
 - Use `cargo-nextest` to speedup testing
 - cache `.cargo` index and downloaded crates to speedup ci
 - disable incremental builds since it's always bulid from scratch
 - use sparse crates.io registry

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com