### PR TITLE
Use `cargo-nextest` to speedup testing

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -10,7 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - run: cargo --locked test --workspace --all-features
+    - uses: taiki-e/install-action@v2
+      with: { tool: cargo-nextest }
+    - run: cargo --locked nextest run --workspace --all-features
+    - run: cargo --locked test --workspace --doc --all-features
 
 on:
   merge_group:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: taiki-e/cache-cargo-install-action@v1
+    - uses: taiki-e/install-action@v2
       with: { tool: cargo-tarpaulin }
     - run: cargo --locked tarpaulin --all-features -- --skip 'proptest::'
     - uses: codecov/codecov-action@v3

--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -21,7 +21,10 @@ jobs:
       with:
         toolchain: ${{ matrix.platform.toolchain }}
         target: ${{ matrix.platform.target }}
-    - run: cargo --locked test --all --all-features
+    - uses: taiki-e/install-action@v2
+      with: { tool: cargo-nextest }
+    - run: cargo --locked nextest run --workspace --all-features
+    - run: cargo --locked test --workspace --doc --all-features
 
   min-versions:
     name: cargo test --shallow-minimal-versions
@@ -47,7 +50,10 @@ jobs:
         ) -Z minimal-versions
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with: { toolchain: stable }
-    - run: cargo --locked test --workspace --all-features
+    - uses: taiki-e/install-action@v2
+      with: { tool: cargo-nextest }
+    - run: cargo --locked nextest run --workspace --all-features
+    - run: cargo --locked test --workspace --doc --all-features
 
   check-features:
     name: cargo hack check --feature-powerset

--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: taiki-e/cache-cargo-install-action@v1
+    - uses: taiki-e/install-action@v2
       with: { tool: cargo-hack }
     - run:
         cargo hack check
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: taiki-e/cache-cargo-install-action@v1
+    - uses: taiki-e/install-action@v2
       with: { tool: cargo-hack }
     - run:
         cargo hack check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,10 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
-    - run: cargo --locked test --all --all-features
+    - uses: taiki-e/install-action@v2
+      with: { tool: cargo-nextest }
+    - run: cargo --locked nextest run --workspace --all-features
+    - run: cargo --locked test --workspace --doc --all-features
 
   fmt:
     name: cargo +nightly fmt --check


### PR DESCRIPTION
Imo this is plenty fast enough and any further changes would only complicate our simple CI setup for no to negligible gain.