### PR TITLE
Release async-compression v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0), 
 
 ## Unreleased
 
+## 0.4.4
+
 - Update `zstd` dependency to `0.13`.
 
 ## 0.4.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-compression"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Wim Looman <wim@nemo157.com>", "Allen Bui <fairingrey@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
With zstd dependencies updated to the next incompatible version, I believe it's time to cut a new release so that the old zstd dependencies can be dropped.