### PR TITLE
expose memlimit settings for xz2 decoders

### DIFF
--- a/src/codec/lzma/decoder.rs
+++ b/src/codec/lzma/decoder.rs
@@ -10,7 +10,13 @@ pub struct LzmaDecoder {
 impl LzmaDecoder {
     pub fn new() -> Self {
         Self {
-            inner: crate::codec::Xz2Decoder::new(),
+            inner: crate::codec::Xz2Decoder::new(u64::max_value()),
+        }
+    }
+
+    pub fn with_memlimit(memlimit: u64) -> Self {
+        Self {
+            inner: crate::codec::Xz2Decoder::new(memlimit),
         }
     }
 }

--- a/src/codec/xz/decoder.rs
+++ b/src/codec/xz/decoder.rs
@@ -11,7 +11,14 @@ pub struct XzDecoder {
 impl XzDecoder {
     pub fn new() -> Self {
         Self {
-            inner: crate::codec::Xz2Decoder::new(),
+            inner: crate::codec::Xz2Decoder::new(u64::max_value()),
+            skip_padding: None,
+        }
+    }
+
+    pub fn with_memlimit(memlimit: u64) -> Self {
+        Self {
+            inner: crate::codec::Xz2Decoder::new(memlimit),
             skip_padding: None,
         }
     }

--- a/src/codec/xz2/decoder.rs
+++ b/src/codec/xz2/decoder.rs
@@ -15,16 +15,16 @@ impl Debug for Xz2Decoder {
 }
 
 impl Xz2Decoder {
-    pub fn new() -> Self {
+    pub fn new(mem_limit: u64) -> Self {
         Self {
-            stream: Stream::new_auto_decoder(u64::max_value(), 0).unwrap(),
+            stream: Stream::new_auto_decoder(mem_limit, 0).unwrap(),
         }
     }
 }
 
 impl Decode for Xz2Decoder {
     fn reinit(&mut self) -> Result<()> {
-        *self = Self::new();
+        *self = Self::new(self.stream.memlimit());
         Ok(())
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -222,7 +222,19 @@ macro_rules! algos {
                 }
             }
         }
-        { @dec }
+        { @dec
+            /// Creates a new decoder, using the specified limit of memory. `Err(Custom { kind:
+            /// Other, error: MemLimit })` can be returned during decoding if the specified limit
+            /// is too small.
+            pub fn with_memlimit(read: $inner, memlimit: u64) -> Self {
+                Self {
+                    inner: crate::$($mod::)+generic::Decoder::new(
+                        read,
+                        crate::codec::XzDecoder::with_memlimit(memlimit),
+                    ),
+                }
+            }
+        }
         );
 
         algos!(@algo lzma ["lzma"] LzmaDecoder LzmaEncoder <$inner>
@@ -237,7 +249,20 @@ macro_rules! algos {
                 }
             }
         }
-        { @dec }
+        { @dec
+            /// Creates a new decoder, using the specified limit of memory. `Err(Custom { kind:
+            /// Other, error: MemLimit })` can be returned during decoding if the specified limit
+            /// is too small.
+            pub fn with_memlimit(read: $inner, memlimit: u64) -> Self {
+                Self {
+                    inner: crate::$($mod::)+generic::Decoder::new(
+                        read,
+                        crate::codec::LzmaDecoder::with_memlimit(memlimit),
+                    ),
+                }
+            }
+
+        }
         );
     }
 }


### PR DESCRIPTION
xz2 decoders are by default configured with a memory limit value of u64::max. This is problematic on targets where there is limited memory available for decoding. e.g. one could run out of memory. By exposing an additional function call `XzDecoder::with_memlimit(..)` and `LzmaDecoder::with_memlimit(..)` users can initialize a decoder with a given memory limit.

Consequently specifying a too low value means the decoder will fail to decompress. On this occasion the decoder will return an `io::Error::Custom` value with the message "MemLimit" to signal it needs to be configured with more memory.

This error is propagated by the chosen interface, `AsyncBufRead` or `AsyncWrite`, therefore no additional error handling has to be implemented to handle this "side effect"