### PR TITLE
Exhaust AsyncBufRead reader

### DIFF
--- a/src/futures/bufread/generic/decoder.rs
+++ b/src/futures/bufread/generic/decoder.rs
@@ -79,11 +79,7 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                         let done = this.decoder.decode(&mut input, output)?;
                         let len = input.written().len();
                         this.reader.as_mut().consume(len);
-                        if done {
-                            State::Flushing
-                        } else {
-                            State::Decoding
-                        }
+                        State::Decoding
                     }
                 }
 

--- a/src/tokio/bufread/generic/decoder.rs
+++ b/src/tokio/bufread/generic/decoder.rs
@@ -79,11 +79,7 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                         let done = this.decoder.decode(&mut input, output)?;
                         let len = input.written().len();
                         this.reader.as_mut().consume(len);
-                        if done {
-                            State::Flushing
-                        } else {
-                            State::Decoding
-                        }
+                        State::Decoding
                     }
                 }
 


### PR DESCRIPTION
When the decoder goes into State::Done, the decoder is considered done with reading. Therefore no calls will be made to the underlying reader. As a consequence, the reader never reaches EOF state. i.e. The AsyncBufRead never returns `Poll::Ready(Ok(&[]))`. This is problematic as this prevents underlaying streams, readers and channels to gracefully shutdown.

To solve this issue, the decoder will make one interation more into state::Decoding. This forces one last read into the underlying reader by calling poll_fill_buffer. before it goes into State::Done via State::Flushing.