### PR TITLE
Replacing panics with errors improves the usability of the crate

### DIFF
--- a/src/codec/bzip2/decoder.rs
+++ b/src/codec/bzip2/decoder.rs
@@ -37,7 +37,7 @@ impl BzDecoder {
         let status = self
             .decompress
             .decompress(input.unwritten(), output.unwritten_mut())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(|e| Error::new(ErrorKind::Other, e))?;
 
         input.advance((self.decompress.total_in() - prior_in) as usize);
         output.advance((self.decompress.total_out() - prior_out) as usize);

--- a/src/codec/bzip2/encoder.rs
+++ b/src/codec/bzip2/encoder.rs
@@ -58,7 +58,7 @@ impl BzEncoder {
         let status = self
             .compress
             .compress(input.unwritten(), output.unwritten_mut(), action)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(|e| Error::new(ErrorKind::Other, e))?;
 
         input.advance((self.compress.total_in() - prior_in) as usize);
         output.advance((self.compress.total_out() - prior_out) as usize);

--- a/src/codec/gzip/encoder.rs
+++ b/src/codec/gzip/encoder.rs
@@ -1,5 +1,5 @@
 use crate::{codec::Encode, util::PartialBuffer};
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 
 use flate2::{Compression, Crc};
 
@@ -71,7 +71,9 @@ impl Encode for GzipEncoder {
                     self.crc.update(&input.written()[prior_written..]);
                 }
 
-                State::Footer(_) | State::Done => panic!("encode after complete"),
+                State::Footer(_) | State::Done => {
+                    return Err(Error::new(ErrorKind::Other, "encode after complete"));
+                }
             };
 
             if input.unwritten().is_empty() || output.unwritten().is_empty() {

--- a/src/codec/gzip/header.rs
+++ b/src/codec/gzip/header.rs
@@ -153,7 +153,10 @@ impl Parser {
                 }
 
                 State::Done => {
-                    panic!("parser used after done");
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "parser used after done",
+                    ));
                 }
             };
         }

--- a/src/codec/xz2/decoder.rs
+++ b/src/codec/xz2/decoder.rs
@@ -1,4 +1,5 @@
-use std::{fmt, io};
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
 
 use xz2::stream::{Action, Status, Stream};
 
@@ -23,7 +24,7 @@ impl Xz2Decoder {
 }
 
 impl Decode for Xz2Decoder {
-    fn reinit(&mut self) -> io::Result<()> {
+    fn reinit(&mut self) -> Result<()> {
         *self = Self::new(self.stream.memlimit());
         Ok(())
     }
@@ -32,7 +33,7 @@ impl Decode for Xz2Decoder {
         &mut self,
         input: &mut PartialBuffer<impl AsRef<[u8]>>,
         output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<bool> {
+    ) -> Result<bool> {
         let previous_in = self.stream.total_in() as usize;
         let previous_out = self.stream.total_out() as usize;
 
@@ -46,18 +47,18 @@ impl Decode for Xz2Decoder {
         match status {
             Status::Ok => Ok(false),
             Status::StreamEnd => Ok(true),
-            Status::GetCheck => panic!("Unexpected lzma integrity check"),
-            Status::MemNeeded => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "More memory needed",
+            Status::GetCheck => Err(Error::new(
+                ErrorKind::Other,
+                "Unexpected lzma integrity check",
             )),
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "More memory needed")),
         }
     }
 
     fn flush(
         &mut self,
         _output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<bool> {
+    ) -> Result<bool> {
         // While decoding flush is a noop
         Ok(true)
     }
@@ -65,7 +66,7 @@ impl Decode for Xz2Decoder {
     fn finish(
         &mut self,
         output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<bool> {
+    ) -> Result<bool> {
         let previous_out = self.stream.total_out() as usize;
 
         let status = self
@@ -77,11 +78,11 @@ impl Decode for Xz2Decoder {
         match status {
             Status::Ok => Ok(false),
             Status::StreamEnd => Ok(true),
-            Status::GetCheck => panic!("Unexpected lzma integrity check"),
-            Status::MemNeeded => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "More memory needed",
+            Status::GetCheck => Err(Error::new(
+                ErrorKind::Other,
+                "Unexpected lzma integrity check",
             )),
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "More memory needed")),
         }
     }
 }

--- a/src/codec/xz2/encoder.rs
+++ b/src/codec/xz2/encoder.rs
@@ -1,4 +1,5 @@
-use std::{fmt, io};
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
 
 use xz2::stream::{Action, Check, LzmaOptions, Status, Stream};
 
@@ -35,7 +36,7 @@ impl Encode for Xz2Encoder {
         &mut self,
         input: &mut PartialBuffer<impl AsRef<[u8]>>,
         output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         let previous_in = self.stream.total_in() as usize;
         let previous_out = self.stream.total_out() as usize;
 
@@ -48,18 +49,18 @@ impl Encode for Xz2Encoder {
 
         match status {
             Status::Ok | Status::StreamEnd => Ok(()),
-            Status::GetCheck => panic!("Unexpected lzma integrity check"),
-            Status::MemNeeded => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "out of memory",
+            Status::GetCheck => Err(Error::new(
+                ErrorKind::Other,
+                "Unexpected lzma integrity check",
             )),
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
         }
     }
 
     fn flush(
         &mut self,
         output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<bool> {
+    ) -> Result<bool> {
         let previous_out = self.stream.total_out() as usize;
 
         let status = self
@@ -71,18 +72,18 @@ impl Encode for Xz2Encoder {
         match status {
             Status::Ok => Ok(false),
             Status::StreamEnd => Ok(true),
-            Status::GetCheck => panic!("Unexpected lzma integrity check"),
-            Status::MemNeeded => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "out of memory",
+            Status::GetCheck => Err(Error::new(
+                ErrorKind::Other,
+                "Unexpected lzma integrity check",
             )),
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
         }
     }
 
     fn finish(
         &mut self,
         output: &mut PartialBuffer<impl AsRef<[u8]> + AsMut<[u8]>>,
-    ) -> io::Result<bool> {
+    ) -> Result<bool> {
         let previous_out = self.stream.total_out() as usize;
 
         let status = self
@@ -94,11 +95,11 @@ impl Encode for Xz2Encoder {
         match status {
             Status::Ok => Ok(false),
             Status::StreamEnd => Ok(true),
-            Status::GetCheck => panic!("Unexpected lzma integrity check"),
-            Status::MemNeeded => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "out of memory",
+            Status::GetCheck => Err(Error::new(
+                ErrorKind::Other,
+                "Unexpected lzma integrity check",
             )),
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
         }
     }
 }

--- a/src/futures/write/generic/decoder.rs
+++ b/src/futures/write/generic/decoder.rs
@@ -83,7 +83,12 @@ impl<W: AsyncWrite, D: Decode> Decoder<W, D> {
                     }
                 }
 
-                State::Done => panic!("Write after end of stream"),
+                State::Done => {
+                    return Poll::Ready(Err(Error::new(
+                        ErrorKind::Other,
+                        "Write after end of stream",
+                    )))
+                }
             };
 
             let produced = output.written().len();

--- a/src/futures/write/generic/encoder.rs
+++ b/src/futures/write/generic/encoder.rs
@@ -2,7 +2,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 
 use crate::{
     codec::Encode,

--- a/src/futures/write/generic/encoder.rs
+++ b/src/futures/write/generic/encoder.rs
@@ -72,7 +72,9 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
                     State::Encoding
                 }
 
-                State::Finishing | State::Done => panic!("Write after close"),
+                State::Finishing | State::Done => {
+                    return Poll::Ready(Err(Error::new(ErrorKind::Other, "Write after close")))
+                }
             };
 
             let produced = output.written().len();
@@ -94,7 +96,9 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
             let done = match this.state {
                 State::Encoding => this.encoder.flush(&mut output)?,
 
-                State::Finishing | State::Done => panic!("Flush after close"),
+                State::Finishing | State::Done => {
+                    return Poll::Ready(Err(Error::new(ErrorKind::Other, "Flush after close")))
+                }
             };
 
             let produced = output.written().len();

--- a/src/tokio/write/generic/decoder.rs
+++ b/src/tokio/write/generic/decoder.rs
@@ -83,7 +83,12 @@ impl<W: AsyncWrite, D: Decode> Decoder<W, D> {
                     }
                 }
 
-                State::Done => panic!("Write after end of stream"),
+                State::Done => {
+                    return Poll::Ready(Err(Error::new(
+                        ErrorKind::Other,
+                        "Write after end of stream",
+                    )))
+                }
             };
 
             let produced = output.written().len();

--- a/src/tokio/write/generic/encoder.rs
+++ b/src/tokio/write/generic/encoder.rs
@@ -2,7 +2,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 
 use crate::{
     codec::Encode,
@@ -72,7 +72,9 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
                     State::Encoding
                 }
 
-                State::Finishing | State::Done => panic!("Write after shutdown"),
+                State::Finishing | State::Done => {
+                    return Poll::Ready(Err(Error::new(ErrorKind::Other, "Write after shutdown")))
+                }
             };
 
             let produced = output.written().len();
@@ -94,7 +96,9 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
             let done = match this.state {
                 State::Encoding => this.encoder.flush(&mut output)?,
 
-                State::Finishing | State::Done => panic!("Flush after shutdown"),
+                State::Finishing | State::Done => {
+                    return Poll::Ready(Err(Error::new(ErrorKind::Other, "Flush after shutdown")))
+                }
             };
 
             let produced = output.written().len();


### PR DESCRIPTION
I hope you'll consider this PR for inclusion in a patch release.

This PR replaces panics with errors. This is important when the crate is being used in, for example, a long running server process where handling an error is preferred to a panic.

This should help with issues such as: #188 or #246 