### PR TITLE
Expose `total_in`/`total_out` from underlying `flate2` encoder types.

### DIFF
--- a/src/codec/flate/encoder.rs
+++ b/src/codec/flate/encoder.rs
@@ -17,6 +17,10 @@ impl FlateEncoder {
         }
     }
 
+    pub(crate) fn get_ref(&self) -> &Compress {
+        &self.compress
+    }
+
     fn encode(
         &mut self,
         input: &mut PartialBuffer<impl AsRef<[u8]>>,

--- a/src/codec/zlib/encoder.rs
+++ b/src/codec/zlib/encoder.rs
@@ -14,6 +14,10 @@ impl ZlibEncoder {
             inner: crate::codec::FlateEncoder::new(level, true),
         }
     }
+
+    pub(crate) fn get_ref(&self) -> &crate::codec::FlateEncoder {
+        &self.inner
+    }
 }
 
 impl Encode for ZlibEncoder {

--- a/src/futures/bufread/generic/encoder.rs
+++ b/src/futures/bufread/generic/encoder.rs
@@ -47,6 +47,10 @@ impl<R: AsyncBufRead, E: Encode> Encoder<R, E> {
         self.project().reader
     }
 
+    pub(crate) fn get_encoder_ref(&self) -> &E {
+        &self.encoder
+    }
+
     pub fn into_inner(self) -> R {
         self.reader
     }

--- a/src/futures/write/generic/encoder.rs
+++ b/src/futures/write/generic/encoder.rs
@@ -51,6 +51,10 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
         self.project().writer.get_pin_mut()
     }
 
+    pub(crate) fn get_encoder_ref(&self) -> &E {
+        &self.encoder
+    }
+
     pub fn into_inner(self) -> W {
         self.writer.into_inner()
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,6 +131,16 @@ macro_rules! algos {
                     ),
                 }
             }
+
+            /// Returns the total number of input bytes which have been processed by this compression object.
+            pub fn total_in(&self) -> u64 {
+                self.inner.get_encoder_ref().get_ref().get_ref().total_in()
+            }
+
+            /// Returns the total number of output bytes which have been produced by this compression object.
+            pub fn total_out(&self) -> u64 {
+                self.inner.get_encoder_ref().get_ref().get_ref().total_out()
+            }
         }
         { @dec }
         );

--- a/src/tokio/bufread/generic/encoder.rs
+++ b/src/tokio/bufread/generic/encoder.rs
@@ -47,6 +47,10 @@ impl<R: AsyncBufRead, E: Encode> Encoder<R, E> {
         self.project().reader
     }
 
+    pub(crate) fn get_encoder_ref(&self) -> &E {
+        &self.encoder
+    }
+
     pub fn into_inner(self) -> R {
         self.reader
     }

--- a/src/tokio/write/generic/encoder.rs
+++ b/src/tokio/write/generic/encoder.rs
@@ -51,6 +51,10 @@ impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
         self.project().writer.get_pin_mut()
     }
 
+    pub(crate) fn get_encoder_ref(&self) -> &E {
+        &self.encoder
+    }
+
     pub fn into_inner(self) -> W {
         self.writer.into_inner()
     }


### PR DESCRIPTION
👋🏻 

This PR is about exposing some more of the underlying `flate2` bits, as the title indicates.

Naturally, when asynchronously writing the compressed output, it can be difficult, otherwise, to determine how much data has been written so far. By exposing the helper methods like `total_in` and `total_out`, it becomes that much easier.

Some thoughts/caveats:

- I do realize that this is somewhat coupling the API to `flate2`, although with `flate2` being 1.x, it should be OK from a stability standpoint.
- Not all compression algorithms used come from `flate2`, so not all encoders can consistently expose these same methods.