### PR TITLE
Migrate from unmaintained xz2 to liblzma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,13 @@ libzstd = { package = "zstd", version = "0.13.1", optional = true, default-featu
 memchr = "2"
 pin-project-lite = "0.2"
 tokio = { version = "1.24.2", optional = true, default-features = false }
-xz2 = { version = "0.1.6", optional = true }
 zstd-safe = { version = "7", optional = true, default-features = false }
 deflate64 = { version = "0.1.5", optional = true }
+
+[target.'cfg(not(async_compression_unstable_liblzma_fork))'.dependencies]
+xz2 = { version = "0.1.6", optional = true }
+[target.'cfg(async_compression_unstable_liblzma_fork)'.dependencies]
+xz2 = { package = "liblzma", version = "0.3.2", optional = true }
 
 [dev-dependencies]
 bytes = "1"
@@ -103,3 +107,6 @@ required-features = ["zlib", "tokio"]
 [[example]]
 name = "zstd_gzip"
 required-features = ["zstd", "gzip", "tokio"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(async_compression_unstable_liblzma_fork)'] }

--- a/src/codec/xz2/decoder.rs
+++ b/src/codec/xz2/decoder.rs
@@ -1,5 +1,8 @@
 use std::{fmt, io};
 
+#[cfg(async_compression_unstable_liblzma_fork)]
+use liblzma::stream::{Action, Status, Stream};
+#[cfg(not(async_compression_unstable_liblzma_fork))]
 use xz2::stream::{Action, Status, Stream};
 
 use crate::{codec::Decode, util::PartialBuffer};

--- a/src/codec/xz2/encoder.rs
+++ b/src/codec/xz2/encoder.rs
@@ -1,5 +1,8 @@
 use std::{fmt, io};
 
+#[cfg(async_compression_unstable_liblzma_fork)]
+use liblzma::stream::{Action, Check, LzmaOptions, Status, Stream};
+#[cfg(not(async_compression_unstable_liblzma_fork))]
 use xz2::stream::{Action, Check, LzmaOptions, Status, Stream};
 
 use crate::{

--- a/tests/utils/algos.rs
+++ b/tests/utils/algos.rs
@@ -169,13 +169,21 @@ algos! {
             pub use crate::utils::impls::sync::to_vec;
 
             pub fn compress(bytes: &[u8]) -> Vec<u8> {
+                #[cfg(not(async_compression_unstable_liblzma_fork))]
                 use xz2::bufread::XzEncoder;
+
+                #[cfg(async_compression_unstable_liblzma_fork)]
+                use liblzma::bufread::XzEncoder;
 
                 to_vec(XzEncoder::new(bytes, 0))
             }
 
             pub fn decompress(bytes: &[u8]) -> Vec<u8> {
+                #[cfg(not(async_compression_unstable_liblzma_fork))]
                 use xz2::bufread::XzDecoder;
+
+                #[cfg(async_compression_unstable_liblzma_fork)]
+                use liblzma::bufread::XzDecoder;
 
                 to_vec(XzDecoder::new(bytes))
             }
@@ -187,8 +195,17 @@ algos! {
             pub use crate::utils::impls::sync::to_vec;
 
             pub fn compress(bytes: &[u8]) -> Vec<u8> {
-                use xz2::bufread::XzEncoder;
-                use xz2::stream::{LzmaOptions, Stream};
+                #[cfg(not(async_compression_unstable_liblzma_fork))]
+                use xz2::{
+                    bufread::XzEncoder,
+                    stream::{LzmaOptions, Stream},
+                };
+
+                #[cfg(async_compression_unstable_liblzma_fork)]
+                use liblzma::{
+                    bufread::XzEncoder,
+                    stream::{LzmaOptions, Stream},
+                };
 
                 to_vec(XzEncoder::new_stream(
                     bytes,
@@ -197,8 +214,17 @@ algos! {
             }
 
             pub fn decompress(bytes: &[u8]) -> Vec<u8> {
-                use xz2::bufread::XzDecoder;
-                use xz2::stream::Stream;
+                #[cfg(not(async_compression_unstable_liblzma_fork))]
+                use xz2::{
+                    bufread::XzDecoder,
+                    stream::Stream,
+                };
+
+                #[cfg(async_compression_unstable_liblzma_fork)]
+                use liblzma::{
+                    bufread::XzDecoder,
+                    stream::Stream,
+                };
 
                 to_vec(XzDecoder::new_stream(
                     bytes,


### PR DESCRIPTION
Hello,
It seems xz2 is unmaintained and the maintainer has stepped down: https://github.com/alexcrichton/xz2-rs/issues/128#issuecomment-2214139875. https://github.com/Portable-Network-Archive/liblzma-rs seems to be the replacement, including a newer version of `xz`, `wasm` support and test updates.
I've kept the module called `xz2` for now. All tests still pass.