### PR TITLE
Update brotli to 7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ zstdmt = ["zstd", "zstd-safe/zstdmt"]
 deflate64 = ["dep:deflate64"]
 
 [dependencies]
-brotli = { version = "6.0", optional = true }
+brotli = { version = "7.0", optional = true }
 bzip2 = { version = "0.4.4", optional = true }
 flate2 = { version = "1.0.13", optional = true }
 futures-core = { version = "0.3", default-features = false }


### PR DESCRIPTION
There were few changes between 6.0.0 and 7.0.0, and it looks like https://github.com/dropbox/rust-brotli/commit/41cadaabb6c650ae518b30509a5fbe43ca8cfab9 was the only breaking one. I confirmed that `cargo test --all-features` still passes.