### PR TITLE
Fix panic: cannot consume from pending buffer

### DIFF
--- a/src/futures/bufread/generic/decoder.rs
+++ b/src/futures/bufread/generic/decoder.rs
@@ -88,7 +88,7 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);
-                        let done = this.decoder.decode(&mut input, output).or_else(|err| {
+                        let res = this.decoder.decode(&mut input, output).or_else(|err| {
                             // ignore the first error, occurs when input is empty
                             // but we need to run decode to flush
                             if first {
@@ -96,13 +96,14 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                             } else {
                                 Err(err)
                             }
-                        })?;
+                        });
 
                         first = false;
 
                         let len = input.written().len();
                         this.reader.as_mut().consume(len);
-                        if done {
+
+                        if res? {
                             State::Flushing
                         } else {
                             State::Decoding

--- a/src/futures/bufread/generic/decoder.rs
+++ b/src/futures/bufread/generic/decoder.rs
@@ -98,10 +98,12 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                             }
                         });
 
-                        first = false;
+                        if !first {
+                            let len = input.written().len();
+                            this.reader.as_mut().consume(len);
+                        }
 
-                        let len = input.written().len();
-                        this.reader.as_mut().consume(len);
+                        first = false;
 
                         if res? {
                             State::Flushing

--- a/src/tokio/bufread/generic/decoder.rs
+++ b/src/tokio/bufread/generic/decoder.rs
@@ -88,7 +88,7 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);
-                        let done = this.decoder.decode(&mut input, output).or_else(|err| {
+                        let res = this.decoder.decode(&mut input, output).or_else(|err| {
                             // ignore the first error, occurs when input is empty
                             // but we need to run decode to flush
                             if first {
@@ -96,13 +96,14 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                             } else {
                                 Err(err)
                             }
-                        })?;
+                        });
 
                         first = false;
 
                         let len = input.written().len();
                         this.reader.as_mut().consume(len);
-                        if done {
+
+                        if res? {
                             State::Flushing
                         } else {
                             State::Decoding

--- a/src/tokio/bufread/generic/decoder.rs
+++ b/src/tokio/bufread/generic/decoder.rs
@@ -98,10 +98,12 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                             }
                         });
 
-                        first = false;
+                        if !first {
+                            let len = input.written().len();
+                            this.reader.as_mut().consume(len);
+                        }
 
-                        let len = input.written().len();
-                        this.reader.as_mut().consume(len);
+                        first = false;
 
                         if res? {
                             State::Flushing


### PR DESCRIPTION
Fixed #298

This PR changes the decoder `do_poll_read` impl, to not advance the buffer on first flush.

The panic is because the decoder try to advance the buffer before polling the underlying buf reader.

~~In this PR I tried a different fix, by making sure `buf.consume` is always called, even on error.
I suspect that previously we didn't consume the buffer on error, and that might have caused the same data to be decompressed again.~~

~~I can't think of anywhere else that could fail, the decoder implementation looks alright.~~