### PR TITLE
Pass through `AsyncBufRead` trait for write-based encoders/decoders

### DIFF
--- a/src/futures/write/generic/decoder.rs
+++ b/src/futures/write/generic/decoder.rs
@@ -10,7 +10,7 @@ use crate::{
     util::PartialBuffer,
 };
 use futures_core::ready;
-use futures_io::{AsyncRead, AsyncWrite, IoSliceMut};
+use futures_io::{AsyncBufRead, AsyncRead, AsyncWrite, IoSliceMut};
 use pin_project_lite::pin_project;
 
 #[derive(Debug)]
@@ -200,5 +200,15 @@ impl<W: AsyncRead, D> AsyncRead for Decoder<W, D> {
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         self.get_pin_mut().poll_read_vectored(cx, bufs)
+    }
+}
+
+impl<W: AsyncBufRead, D> AsyncBufRead for Decoder<W, D> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.get_pin_mut().poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_pin_mut().consume(amt)
     }
 }

--- a/src/futures/write/generic/encoder.rs
+++ b/src/futures/write/generic/encoder.rs
@@ -10,7 +10,7 @@ use crate::{
     util::PartialBuffer,
 };
 use futures_core::ready;
-use futures_io::{AsyncRead, AsyncWrite, IoSliceMut};
+use futures_io::{AsyncBufRead, AsyncRead, AsyncWrite, IoSliceMut};
 use pin_project_lite::pin_project;
 
 #[derive(Debug)]
@@ -197,5 +197,15 @@ impl<W: AsyncRead, E> AsyncRead for Encoder<W, E> {
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         self.get_pin_mut().poll_read_vectored(cx, bufs)
+    }
+}
+
+impl<W: AsyncBufRead, E> AsyncBufRead for Encoder<W, E> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.get_pin_mut().poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_pin_mut().consume(amt)
     }
 }

--- a/src/futures/write/macros/decoder.rs
+++ b/src/futures/write/macros/decoder.rs
@@ -99,6 +99,19 @@ macro_rules! decoder {
             }
         }
 
+        impl<$inner: futures_io::AsyncBufRead> futures_io::AsyncBufRead for $name<$inner> {
+            fn poll_fill_buf(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>
+            ) -> std::task::Poll<std::io::Result<&[u8]>> {
+                self.get_pin_mut().poll_fill_buf(cx)
+            }
+
+            fn consume(self: std::pin::Pin<&mut Self>, amt: usize) {
+                self.get_pin_mut().consume(amt)
+            }
+        }
+
         const _: () = {
             fn _assert() {
                 use crate::util::{_assert_send, _assert_sync};

--- a/src/futures/write/macros/encoder.rs
+++ b/src/futures/write/macros/encoder.rs
@@ -96,6 +96,19 @@ macro_rules! encoder {
             }
         }
 
+        impl<$inner: futures_io::AsyncBufRead> futures_io::AsyncBufRead for $name<$inner> {
+            fn poll_fill_buf(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>
+            ) -> std::task::Poll<std::io::Result<&[u8]>> {
+                self.get_pin_mut().poll_fill_buf(cx)
+            }
+
+            fn consume(self: std::pin::Pin<&mut Self>, amt: usize) {
+                self.get_pin_mut().consume(amt)
+            }
+        }
+
         const _: () = {
             fn _assert() {
                 use crate::util::{_assert_send, _assert_sync};

--- a/src/tokio/write/generic/decoder.rs
+++ b/src/tokio/write/generic/decoder.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use futures_core::ready;
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 #[derive(Debug)]
 enum State {
@@ -194,5 +194,15 @@ impl<W: AsyncRead, D> AsyncRead for Decoder<W, D> {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         self.get_pin_mut().poll_read(cx, buf)
+    }
+}
+
+impl<W: AsyncBufRead, D> AsyncBufRead for Decoder<W, D> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.get_pin_mut().poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_pin_mut().consume(amt)
     }
 }

--- a/src/tokio/write/generic/encoder.rs
+++ b/src/tokio/write/generic/encoder.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use futures_core::ready;
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 #[derive(Debug)]
 enum State {
@@ -191,5 +191,15 @@ impl<W: AsyncRead, E> AsyncRead for Encoder<W, E> {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         self.get_pin_mut().poll_read(cx, buf)
+    }
+}
+
+impl<W: AsyncBufRead, E> AsyncBufRead for Encoder<W, E> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.get_pin_mut().poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_pin_mut().consume(amt)
     }
 }

--- a/src/tokio/write/macros/decoder.rs
+++ b/src/tokio/write/macros/decoder.rs
@@ -91,6 +91,19 @@ macro_rules! decoder {
             }
         }
 
+        impl<$inner: tokio::io::AsyncBufRead> tokio::io::AsyncBufRead for $name<$inner> {
+            fn poll_fill_buf(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>
+            ) -> std::task::Poll<std::io::Result<&[u8]>> {
+                self.get_pin_mut().poll_fill_buf(cx)
+            }
+
+            fn consume(self: std::pin::Pin<&mut Self>, amt: usize) {
+                self.get_pin_mut().consume(amt)
+            }
+        }
+
         const _: () = {
             fn _assert() {
                 use crate::util::{_assert_send, _assert_sync};

--- a/src/tokio/write/macros/encoder.rs
+++ b/src/tokio/write/macros/encoder.rs
@@ -88,6 +88,19 @@ macro_rules! encoder {
             }
         }
 
+        impl<$inner: tokio::io::AsyncBufRead> tokio::io::AsyncBufRead for $name<$inner> {
+            fn poll_fill_buf(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>
+            ) -> std::task::Poll<std::io::Result<&[u8]>> {
+                self.get_pin_mut().poll_fill_buf(cx)
+            }
+
+            fn consume(self: std::pin::Pin<&mut Self>, amt: usize) {
+                self.get_pin_mut().consume(amt)
+            }
+        }
+
         const _: () = {
             fn _assert() {
                 use crate::util::{_assert_send, _assert_sync};


### PR DESCRIPTION
Follow-up to #297 