### PR TITLE
fix(flate encoder): do not mark internal state as flushed if we ran out of buffer space

### DIFF
--- a/src/codec/flate/encoder.rs
+++ b/src/codec/flate/encoder.rs
@@ -83,8 +83,9 @@ impl Encode for FlateEncoder {
             }
         }
 
-        self.flushed = true;
-        Ok(!output.unwritten().is_empty())
+        let internal_flushed = !output.unwritten().is_empty();
+        self.flushed = internal_flushed;
+        Ok(internal_flushed)
     }
 
     fn finish(


### PR DESCRIPTION
There may be data remaining in the internal state of the encoder.

Without the fix on a second call to flush() when the caller makes space in the output buffer we will write nothing into the buffer.