### PR TITLE
Expose total_in/total_out in DeflateEncoder

### DIFF
--- a/src/codec/deflate/encoder.rs
+++ b/src/codec/deflate/encoder.rs
@@ -14,6 +14,10 @@ impl DeflateEncoder {
             inner: crate::codec::FlateEncoder::new(level, false),
         }
     }
+
+    pub(crate) fn get_ref(&self) -> &crate::codec::FlateEncoder {
+        &self.inner
+    }
 }
 
 impl Encode for DeflateEncoder {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -98,6 +98,16 @@ macro_rules! algos {
                     ),
                 }
             }
+
+            /// Returns the total number of input bytes which have been processed by this compression object.
+            pub fn total_in(&self) -> u64 {
+                self.inner.get_encoder_ref().get_ref().get_ref().total_in()
+            }
+
+            /// Returns the total number of output bytes which have been produced by this compression object.
+            pub fn total_out(&self) -> u64 {
+                self.inner.get_encoder_ref().get_ref().get_ref().total_out()
+            }
         }
         { @dec }
         );


### PR DESCRIPTION
Expose the underlying `total_in` and `total_out` methods in `DeflateEncoder`, in the same fashion as #278.