### PR TITLE
xz: add multi-thread support

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -19,7 +19,7 @@ jobs:
         tar xf wasi-sysroot.tar.gz --strip-components=1 -C wasi-sysroot
     - run: |
         export "CFLAGS_wasm32_wasip1_threads=--sysroot=${{ github.workspace }}/wasi-sysroot -I${{ github.workspace }}/wasi-sysroot/include/wasm32-wasip1-threads -L-I${{ github.workspace }}/wasi-sysroot/lib/wasm32-wasip1-threads"
-        cargo +nightly build --lib --features all --target wasm32-wasip1-threads
+        cargo +nightly build --lib --features all-implementations,brotli,bzip2,deflate,gzip,lz4,lzma,xz,zlib,zstd,deflate64 --target wasm32-wasip1-threads
 
 on:
     merge_group:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # groups
 all = ["all-implementations", "all-algorithms"]
 all-implementations = ["futures-io", "tokio"]
-all-algorithms = ["brotli", "bzip2", "deflate", "gzip", "lz4", "lzma", "xz", "zlib", "zstd", "deflate64"]
+all-algorithms = ["brotli", "bzip2", "deflate", "gzip", "lz4", "lzma", "xz-parallel", "xz", "zlib", "zstd", "deflate64"]
 
 # algorithms
 deflate = ["flate2"]
@@ -28,6 +28,7 @@ gzip = ["flate2"]
 lz4 = ["dep:lz4"]
 lzma = ["dep:liblzma"]
 xz = ["lzma"]
+xz-parallel = ["xz", "liblzma/parallel"]
 xz2 = ["xz"]
 zlib = ["flate2"]
 zstd = ["libzstd", "zstd-safe"]
@@ -45,7 +46,7 @@ lz4 = { version = "1.28.1", optional = true }
 memchr = "2"
 pin-project-lite = "0.2"
 tokio = { version = "1.24.2", optional = true, default-features = false }
-liblzma = { version = "0.4.0", optional = true }
+liblzma = { version = "0.4.2", optional = true }
 zstd-safe = { version = "7", optional = true, default-features = false }
 deflate64 = { version = "0.1.5", optional = true }
 

--- a/src/codec/xz/decoder.rs
+++ b/src/codec/xz/decoder.rs
@@ -22,6 +22,14 @@ impl XzDecoder {
             skip_padding: None,
         }
     }
+
+    #[cfg(feature = "xz-parallel")]
+    pub fn parallel(threads: u32, memlimit: u64) -> Self {
+        Self {
+            inner: crate::codec::Xz2Decoder::parallel(threads, memlimit),
+            skip_padding: None,
+        }
+    }
 }
 
 impl Decode for XzDecoder {

--- a/src/codec/xz/decoder.rs
+++ b/src/codec/xz/decoder.rs
@@ -24,7 +24,7 @@ impl XzDecoder {
     }
 
     #[cfg(feature = "xz-parallel")]
-    pub fn parallel(threads: u32, memlimit: u64) -> Self {
+    pub fn parallel(threads: std::num::NonZeroU32, memlimit: u64) -> Self {
         Self {
             inner: crate::codec::Xz2Decoder::parallel(threads, memlimit),
             skip_padding: None,

--- a/src/codec/xz/encoder.rs
+++ b/src/codec/xz/encoder.rs
@@ -13,6 +13,13 @@ impl XzEncoder {
             inner: crate::codec::Xz2Encoder::new(crate::codec::Xz2FileFormat::Xz, level),
         }
     }
+
+    #[cfg(feature = "xz-parallel")]
+    pub fn parallel(level: u32, threads: u32) -> Self {
+        Self {
+            inner: crate::codec::Xz2Encoder::xz_parallel(level, threads),
+        }
+    }
 }
 
 impl Encode for XzEncoder {

--- a/src/codec/xz/encoder.rs
+++ b/src/codec/xz/encoder.rs
@@ -15,7 +15,7 @@ impl XzEncoder {
     }
 
     #[cfg(feature = "xz-parallel")]
-    pub fn parallel(level: u32, threads: u32) -> Self {
+    pub fn parallel(threads: std::num::NonZeroU32, level: u32) -> Self {
         Self {
             inner: crate::codec::Xz2Encoder::xz_parallel(level, threads),
         }

--- a/src/codec/xz2/decoder.rs
+++ b/src/codec/xz2/decoder.rs
@@ -7,7 +7,7 @@ use crate::{codec::Decode, util::PartialBuffer};
 pub struct Xz2Decoder {
     stream: Stream,
     #[cfg(feature = "xz-parallel")]
-    threads: Option<u32>,
+    threads: Option<std::num::NonZeroU32>,
 }
 
 impl fmt::Debug for Xz2Decoder {
@@ -26,10 +26,10 @@ impl Xz2Decoder {
     }
 
     #[cfg(feature = "xz-parallel")]
-    pub fn parallel(threads: u32, mem_limit: u64) -> Self {
+    pub fn parallel(threads: std::num::NonZeroU32, mem_limit: u64) -> Self {
         Self {
             stream: liblzma::stream::MtStreamBuilder::new()
-                .threads(threads)
+                .threads(threads.get())
                 .timeout_ms(300)
                 .memlimit_stop(mem_limit)
                 .decoder()

--- a/src/codec/xz2/encoder.rs
+++ b/src/codec/xz2/encoder.rs
@@ -10,7 +10,7 @@ use crate::{
 pub struct Xz2Encoder {
     stream: Stream,
     #[cfg(feature = "xz-parallel")]
-    threads: Option<u32>,
+    threads: Option<std::num::NonZeroU32>,
 }
 
 impl fmt::Debug for Xz2Encoder {
@@ -36,9 +36,9 @@ impl Xz2Encoder {
     }
 
     #[cfg(feature = "xz-parallel")]
-    pub fn xz_parallel(level: u32, threads: u32) -> Self {
+    pub fn xz_parallel(level: u32, threads: std::num::NonZeroU32) -> Self {
         let stream = liblzma::stream::MtStreamBuilder::new()
-            .threads(threads)
+            .threads(threads.get())
             .timeout_ms(300)
             .preset(level)
             .check(Check::Crc64)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,11 @@
 )]
 //!
 
+//! ## Multi-thread support
+//! The `xz` compression algorithm supports multi-threaded compression and decompression.
+//! Enable the `xz-parallel` feature to enable multi-threading support.
+//!
+
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![warn(
     missing_docs,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -252,6 +252,19 @@ macro_rules! algos {
                     ),
                 }
             }
+
+            /// Creates a new multi-threaded encoder.
+            ///
+            /// Note that flushing will severely impact multi-threaded performance.
+            #[cfg(feature = "xz-parallel")]
+            pub fn parallel(inner: $inner, level: crate::Level, threads: u32) -> Self {
+                Self {
+                    inner: crate::$($mod::)+generic::Encoder::new(
+                        inner,
+                        crate::codec::XzEncoder::parallel(level.into_xz2(), threads),
+                    ),
+                }
+            }
         }
         { @dec
             /// Creates a new decoder with the specified limit of memory.
@@ -264,6 +277,32 @@ macro_rules! algos {
                     inner: crate::$($mod::)+generic::Decoder::new(
                         read,
                         crate::codec::XzDecoder::with_memlimit(memlimit),
+                    ),
+                }
+            }
+
+            /// Creates a new multi-threaded decoder.
+            #[cfg(feature = "xz-parallel")]
+            pub fn parallel(read: $inner, threads: u32) -> Self {
+                Self {
+                    inner: crate::$($mod::)+generic::Decoder::new(
+                        read,
+                        crate::codec::XzDecoder::parallel(threads, u64::MAX),
+                    ),
+                }
+            }
+
+            /// Creates a new multi-threaded decoder with the specified limit of memory.
+            ///
+            /// # Errors
+            ///
+            /// An IO error may be returned during decoding if the specified limit is too small.
+            #[cfg(feature = "xz-parallel")]
+            pub fn parallel_with_mem_limit(read: $inner, threads: u32, memlimit: u64) -> Self {
+                Self {
+                    inner: crate::$($mod::)+generic::Decoder::new(
+                        read,
+                        crate::codec::XzDecoder::parallel(threads, memlimit),
                     ),
                 }
             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -257,11 +257,11 @@ macro_rules! algos {
             ///
             /// Note that flushing will severely impact multi-threaded performance.
             #[cfg(feature = "xz-parallel")]
-            pub fn parallel(inner: $inner, level: crate::Level, threads: u32) -> Self {
+            pub fn parallel(inner: $inner, level: crate::Level, threads: std::num::NonZeroU32) -> Self {
                 Self {
                     inner: crate::$($mod::)+generic::Encoder::new(
                         inner,
-                        crate::codec::XzEncoder::parallel(level.into_xz2(), threads),
+                        crate::codec::XzEncoder::parallel(threads, level.into_xz2()),
                     ),
                 }
             }
@@ -283,7 +283,7 @@ macro_rules! algos {
 
             /// Creates a new multi-threaded decoder.
             #[cfg(feature = "xz-parallel")]
-            pub fn parallel(read: $inner, threads: u32) -> Self {
+            pub fn parallel(read: $inner, threads: std::num::NonZeroU32) -> Self {
                 Self {
                     inner: crate::$($mod::)+generic::Decoder::new(
                         read,
@@ -298,7 +298,7 @@ macro_rules! algos {
             ///
             /// An IO error may be returned during decoding if the specified limit is too small.
             #[cfg(feature = "xz-parallel")]
-            pub fn parallel_with_mem_limit(read: $inner, threads: u32, memlimit: u64) -> Self {
+            pub fn parallel_with_mem_limit(read: $inner, threads: std::num::NonZeroU32, memlimit: u64) -> Self {
                 Self {
                     inner: crate::$($mod::)+generic::Decoder::new(
                         read,

--- a/tests/utils/algos.rs
+++ b/tests/utils/algos.rs
@@ -230,3 +230,90 @@ algos! {
         }
     }
 }
+
+macro_rules! io_algo_parallel {
+    ($impl:ident, $algo:ident($encoder:ident, $decoder:ident)) => {
+        pub mod $impl {
+            pub mod read {
+                pub use crate::utils::impls::$impl::read::{poll_read, to_vec};
+            }
+
+            pub mod bufread {
+                pub use crate::utils::impls::$impl::bufread::{from, AsyncBufRead};
+                pub use async_compression::$impl::bufread::{
+                    $decoder as Decoder, $encoder as Encoder,
+                };
+
+                use crate::utils::{pin_mut, Level};
+
+                pub fn compress(input: impl AsyncBufRead) -> Vec<u8> {
+                    pin_mut!(input);
+                    super::read::to_vec(Encoder::parallel(input, Level::Fastest, 16))
+                }
+
+                pub fn decompress(input: impl AsyncBufRead) -> Vec<u8> {
+                    pin_mut!(input);
+                    super::read::to_vec(Decoder::parallel(input, 16))
+                }
+            }
+
+            pub mod write {
+                pub use crate::utils::impls::$impl::write::to_vec;
+                pub use async_compression::$impl::write::{
+                    $decoder as Decoder, $encoder as Encoder,
+                };
+
+                use crate::utils::Level;
+
+                pub fn compress(input: &[Vec<u8>], limit: usize) -> Vec<u8> {
+                    to_vec(
+                        input,
+                        |input| Box::pin(Encoder::parallel(input, Level::Fastest, 16)),
+                        limit,
+                    )
+                }
+
+                pub fn decompress(input: &[Vec<u8>], limit: usize) -> Vec<u8> {
+                    to_vec(input, |input| Box::pin(Decoder::parallel(input, 16)), limit)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! algos_parallel {
+    ($(pub mod $name:ident($feat:literal, $encoder:ident, $decoder:ident) { pub mod sync { $($tt:tt)* } })*) => {
+        $(
+            #[cfg(feature = $feat)]
+            pub mod $name {
+                pub mod sync { $($tt)* }
+
+                #[cfg(feature = "futures-io")]
+                io_algo_parallel!(futures, $name($encoder, $decoder));
+
+                #[cfg(feature = "tokio")]
+                io_algo_parallel!(tokio, $name($encoder, $decoder));
+            }
+        )*
+    }
+}
+
+algos_parallel! {
+    pub mod xz_parallel("xz-parallel", XzEncoder, XzDecoder) {
+        pub mod sync {
+            pub use crate::utils::impls::sync::to_vec;
+
+            pub fn compress(bytes: &[u8]) -> Vec<u8> {
+                use liblzma::bufread::XzEncoder;
+
+                to_vec(XzEncoder::new(bytes, 0))
+            }
+
+            pub fn decompress(bytes: &[u8]) -> Vec<u8> {
+                use liblzma::bufread::XzDecoder;
+
+                to_vec(XzDecoder::new(bytes))
+            }
+        }
+    }
+}

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -6,6 +6,9 @@ mod utils;
 
 test_cases!(xz);
 
+#[cfg(feature = "xz-parallel")]
+test_cases!(xz_parallel);
+
 #[allow(unused)]
 use utils::{algos::xz::sync, InputStream};
 


### PR DESCRIPTION
Adds `XzEncoder::parallel` and `XzDecoder::parallel` methods that enable multi-threaded compression and decompression.

Care must be taken not that call `flush()` on the encoder in quick succession, as this would severely impact multi-threaded compression performance.

Gated by the `xz-parallel` crate feature.