### PR TITLE
publish: exclude testing artifacts from being published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ license.workspace = true
 categories.workspace = true
 edition.workspace = true
 version = "0.4.28"
+exclude = [
+    "tests/artifacts/",
+]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
About 170KB, not a lot for individual tarball but given how many downloads are made from crates.io it's indeed quite large

It can be seem as a kind of optimization for crates.io CDN and caching

IIRC another crate has done the same and some debian maintainers have complained about not being about to run test, but I can't remember which.

Not sure if our crate is on debian given that we don't even maintian MSRV 