### PR TITLE
Add repository to Cargo.toml package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ description = """
 Adaptors between compression crates and Rust's modern asynchronous IO types.
 """
 authors.workspace = true
+repository.workspace = true
 license.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION
A link to this crate's repository does not appear on crates.io and I'm assuming this is the reason for that.