### PR TITLE
Flush compressed data out of encoders more often

### DIFF
--- a/crates/async-compression/src/tokio/bufread/generic/encoder.rs
+++ b/crates/async-compression/src/tokio/bufread/generic/encoder.rs
@@ -13,6 +13,7 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 enum State {
     Encoding,
     Flushing,
+    Finishing,
     Done,
 }
 
@@ -68,27 +69,53 @@ impl<R: AsyncBufRead, E: Encode> Encoder<R, E> {
         output: &mut PartialBuffer<&mut [u8]>,
     ) -> Poll<Result<()>> {
         let mut this = self.project();
+        let mut read = 0usize;
 
         loop {
             *this.state = match this.state {
                 State::Encoding => {
-                    let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
-                    if input.is_empty() {
-                        State::Flushing
-                    } else {
-                        let mut input = PartialBuffer::new(input);
-                        this.encoder.encode(&mut input, output)?;
-                        let len = input.written().len();
-                        this.reader.as_mut().consume(len);
-                        State::Encoding
+                    let res = this.reader.as_mut().poll_fill_buf(cx);
+
+                    match res {
+                        Poll::Pending => {
+                            if read == 0 {
+                                return Poll::Pending;
+                            } else {
+                                State::Flushing
+                            }
+                        }
+                        Poll::Ready(res) => {
+                            let input = res?;
+
+                            if input.is_empty() {
+                                State::Finishing
+                            } else {
+                                let mut input = PartialBuffer::new(input);
+                                this.encoder.encode(&mut input, output)?;
+                                let len = input.written().len();
+                                this.reader.as_mut().consume(len);
+                                read += len;
+
+                                State::Encoding
+                            }
+                        }
                     }
                 }
 
                 State::Flushing => {
+                    if this.encoder.flush(output)? {
+                        read = 0;
+                        State::Encoding
+                    } else {
+                        State::Flushing
+                    }
+                }
+
+                State::Finishing => {
                     if this.encoder.finish(output)? {
                         State::Done
                     } else {
-                        State::Flushing
+                        State::Finishing
                     }
                 }
 

--- a/crates/async-compression/tests/utils/impls.rs
+++ b/crates/async-compression/tests/utils/impls.rs
@@ -104,7 +104,8 @@ pub mod tokio {
         pub fn to_vec(read: impl AsyncRead) -> Vec<u8> {
             let mut output = Cursor::new(vec![0; 102_400]);
             pin_mut!(read);
-            let len = block_on(copy_buf(BufReader::with_capacity(2, read), &mut output)).unwrap();
+            // With more flushing from encoders, 4 appears to be the minimal buffer size that works.
+            let len = block_on(copy_buf(BufReader::with_capacity(4, read), &mut output)).unwrap();
             let mut output = output.into_inner();
             output.truncate(len as usize);
             output

--- a/crates/async-compression/tests/utils/impls.rs
+++ b/crates/async-compression/tests/utils/impls.rs
@@ -32,7 +32,8 @@ pub mod futures {
             // All current test cases are < 100kB
             let mut output = Cursor::new(vec![0; 102_400]);
             pin_mut!(read);
-            let len = block_on(copy_buf(BufReader::with_capacity(2, read), &mut output)).unwrap();
+            // With more flushing from encoders, 4 appears to be the minimal buffer size that works.
+            let len = block_on(copy_buf(BufReader::with_capacity(4, read), &mut output)).unwrap();
             let mut output = output.into_inner();
             output.truncate(len as usize);
             output


### PR DESCRIPTION
Currently flush() is not getting called so compressed output is not returned to the client the encoder until input is fully read(). In my use case, flushing more often is necessary as otherwise it appears to the client the data gets 'buffered'.

There's been a previous PR here and some discussion https://github.com/Nullus157/async-compression/pull/155 but appears to be abandonded so if there's interest in this fix, this PR tries this again.
The tests are passing with this change.