### PR TITLE
Disable nightly feature `doc_auto_cfg` on docsrs

### DIFF
--- a/crates/async-compression/src/lib.rs
+++ b/crates/async-compression/src/lib.rs
@@ -143,7 +143,7 @@
 //! Enable the `xz-parallel` feature to enable multi-threading support.
 //!
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(all), allow(unused))]
 
 #[macro_use]

--- a/crates/compression-codecs/src/lib.rs
+++ b/crates/compression-codecs/src/lib.rs
@@ -1,6 +1,6 @@
 //! Adaptors for various compression algorithms.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::io::Result;
 

--- a/crates/compression-core/src/lib.rs
+++ b/crates/compression-core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Abstractions for compression algorithms.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod level;
 pub mod unshared;


### PR DESCRIPTION
Since this feature is merged into `doc_cfg` in rust-lang/rust#138907