### PR TITLE
Re-export core in codecs

### DIFF
--- a/crates/compression-codecs/src/lib.rs
+++ b/crates/compression-codecs/src/lib.rs
@@ -4,6 +4,8 @@
 
 use std::io::Result;
 
+pub use compression_core as core;
+
 #[cfg(feature = "brotli")]
 pub mod brotli;
 #[cfg(feature = "bzip2")]


### PR DESCRIPTION
It's impossible to use codecs without also importing core