### PR TITLE
Early return in `do_poll_read` instead of keep polling

### DIFF
--- a/crates/async-compression/src/generic/bufread/encoder.rs
+++ b/crates/async-compression/src/generic/bufread/encoder.rs
@@ -35,9 +35,12 @@ impl Encoder {
                 State::Encoding(mut read) => match input.as_mut() {
                     None => {
                         if read == 0 {
-                            // Poll for more data
-                            // TODO (nobodyxu): Return Ok if `!output.written().is_empty()`
-                            break;
+                            if output.written().is_empty() {
+                                // Poll for more data
+                                break;
+                            } else {
+                                return ControlFlow::Break(Ok(()));
+                            }
                         } else {
                             State::Flushing
                         }


### PR DESCRIPTION
if there're some data already written to
`output`, so that the next component in pipeline
can process it instead of being blocked.