### PR TITLE
Simplify `WriteBuffer`: Rm `unwritten_initialized_mut`

### DIFF
--- a/crates/compression-codecs/src/brotli/decoder.rs
+++ b/crates/compression-codecs/src/brotli/decoder.rs
@@ -36,15 +36,13 @@ impl BrotliDecoder {
         input: &mut PartialBuffer<&[u8]>,
         output: &mut WriteBuffer<'_>,
     ) -> io::Result<BrotliResult> {
-        output.initialize_unwritten();
-
         let in_buf = input.unwritten();
-        let out_buf = output.unwritten_initialized_mut();
+        let out_buf = output.initialize_unwritten();
 
         let mut input_len = 0;
         let mut output_len = 0;
 
-        let status = match BrotliDecompressStream(
+        let result = match BrotliDecompressStream(
             &mut in_buf.len(),
             &mut input_len,
             in_buf,
@@ -54,14 +52,14 @@ impl BrotliDecoder {
             &mut 0,
             &mut self.state,
         ) {
-            BrotliResult::ResultFailure => return Err(io::Error::other("brotli error")),
-            status => status,
+            BrotliResult::ResultFailure => Err(io::Error::other("brotli error")),
+            status => Ok(status),
         };
 
         input.advance(input_len);
         output.advance(output_len);
 
-        Ok(status)
+        result
     }
 }
 

--- a/crates/compression-codecs/src/brotli/encoder.rs
+++ b/crates/compression-codecs/src/brotli/encoder.rs
@@ -25,15 +25,13 @@ impl BrotliEncoder {
         output: &mut WriteBuffer<'_>,
         op: BrotliEncoderOperation,
     ) -> io::Result<()> {
-        output.initialize_unwritten();
-
         let in_buf = input.unwritten();
-        let out_buf = output.unwritten_initialized_mut();
+        let out_buf = output.initialize_unwritten();
 
         let mut input_len = 0;
         let mut output_len = 0;
 
-        if !self.state.compress_stream(
+        let result = if !self.state.compress_stream(
             op,
             &mut in_buf.len(),
             in_buf,
@@ -44,13 +42,15 @@ impl BrotliEncoder {
             &mut None,
             &mut |_, _, _, _| (),
         ) {
-            return Err(io::Error::other("brotli error"));
-        }
+            Err(io::Error::other("brotli error"))
+        } else {
+            Ok(())
+        };
 
         input.advance(input_len);
         output.advance(output_len);
 
-        Ok(())
+        result
     }
 }
 

--- a/crates/compression-codecs/src/bzip2/encoder.rs
+++ b/crates/compression-codecs/src/bzip2/encoder.rs
@@ -52,24 +52,18 @@ impl BzEncoder {
         output: &mut WriteBuffer<'_>,
         action: Action,
     ) -> io::Result<Status> {
-        output.initialize_unwritten();
-
         let prior_in = self.compress.total_in();
         let prior_out = self.compress.total_out();
 
-        let status = self
+        let result = self
             .compress
-            .compress(
-                input.unwritten(),
-                output.unwritten_initialized_mut(),
-                action,
-            )
-            .map_err(io::Error::other)?;
+            .compress(input.unwritten(), output.initialize_unwritten(), action)
+            .map_err(io::Error::other);
 
         input.advance((self.compress.total_in() - prior_in) as usize);
         output.advance((self.compress.total_out() - prior_out) as usize);
 
-        Ok(status)
+        result
     }
 }
 

--- a/crates/compression-codecs/src/deflate64/decoder.rs
+++ b/crates/compression-codecs/src/deflate64/decoder.rs
@@ -26,11 +26,9 @@ impl Deflate64Decoder {
         input: &mut PartialBuffer<&[u8]>,
         output: &mut WriteBuffer<'_>,
     ) -> Result<bool> {
-        output.initialize_unwritten();
-
         let result = self
             .inflater
-            .inflate(input.unwritten(), output.unwritten_initialized_mut());
+            .inflate(input.unwritten(), output.initialize_unwritten());
 
         input.advance(result.bytes_consumed);
         output.advance(result.bytes_written);

--- a/crates/compression-codecs/src/flate/decoder.rs
+++ b/crates/compression-codecs/src/flate/decoder.rs
@@ -23,21 +23,17 @@ impl FlateDecoder {
         output: &mut WriteBuffer<'_>,
         flush: FlushDecompress,
     ) -> io::Result<Status> {
-        output.initialize_unwritten();
-
         let prior_in = self.decompress.total_in();
         let prior_out = self.decompress.total_out();
 
-        let status = self.decompress.decompress(
-            input.unwritten(),
-            output.unwritten_initialized_mut(),
-            flush,
-        )?;
+        let result =
+            self.decompress
+                .decompress(input.unwritten(), output.initialize_unwritten(), flush);
 
         input.advance((self.decompress.total_in() - prior_in) as usize);
         output.advance((self.decompress.total_out() - prior_out) as usize);
 
-        Ok(status)
+        Ok(result?)
     }
 }
 

--- a/crates/compression-codecs/src/flate/encoder.rs
+++ b/crates/compression-codecs/src/flate/encoder.rs
@@ -28,19 +28,17 @@ impl FlateEncoder {
         output: &mut WriteBuffer<'_>,
         flush: FlushCompress,
     ) -> io::Result<Status> {
-        output.initialize_unwritten();
-
         let prior_in = self.compress.total_in();
         let prior_out = self.compress.total_out();
 
-        let status =
+        let result =
             self.compress
-                .compress(input.unwritten(), output.unwritten_initialized_mut(), flush)?;
+                .compress(input.unwritten(), output.initialize_unwritten(), flush);
 
         input.advance((self.compress.total_in() - prior_in) as usize);
         output.advance((self.compress.total_out() - prior_out) as usize);
 
-        Ok(status)
+        Ok(result?)
     }
 }
 

--- a/crates/compression-codecs/src/lz4/encoder.rs
+++ b/crates/compression-codecs/src/lz4/encoder.rs
@@ -117,8 +117,8 @@ impl Lz4Encoder {
             Lz4Fn::Flush | Lz4Fn::End => self.flush_buffer_size,
         };
 
-        output.initialize_unwritten();
-        let output_len = output.unwritten_initialized_mut().len();
+        let out_buf = output.initialize_unwritten();
+        let output_len = out_buf.len();
 
         let (dst_buffer, dst_size, maybe_internal_buffer) = if min_dst_size > output_len {
             let buffer_size = self.block_buffer_size;
@@ -132,11 +132,7 @@ impl Lz4Encoder {
                 Some(buffer),
             )
         } else {
-            (
-                output.unwritten_initialized_mut().as_mut_ptr(),
-                output_len,
-                None,
-            )
+            (out_buf.as_mut_ptr(), output_len, None)
         };
 
         let len = match lz4_fn {

--- a/crates/compression-codecs/src/xz2/decoder.rs
+++ b/crates/compression-codecs/src/xz2/decoder.rs
@@ -62,10 +62,9 @@ impl Xz2Decoder {
     ) -> io::Result<bool> {
         let previous_out = self.stream.total_out() as usize;
 
-        output.initialize_unwritten();
         let status = self
             .stream
-            .process(input, output.unwritten_initialized_mut(), action)?;
+            .process(input, output.initialize_unwritten(), action)?;
 
         output.advance(self.stream.total_out() as usize - previous_out);
 

--- a/crates/compression-codecs/src/xz2/encoder.rs
+++ b/crates/compression-codecs/src/xz2/encoder.rs
@@ -88,12 +88,9 @@ impl Xz2Encoder {
         let previous_in = self.stream.total_in() as usize;
         let previous_out = self.stream.total_out() as usize;
 
-        output.initialize_unwritten();
-        let res = self.stream.process(
-            input.unwritten(),
-            output.unwritten_initialized_mut(),
-            action,
-        );
+        let res = self
+            .stream
+            .process(input.unwritten(), output.initialize_unwritten(), action);
 
         input.advance(self.stream.total_in() as usize - previous_in);
         output.advance(self.stream.total_out() as usize - previous_out);

--- a/crates/compression-codecs/src/zstd/decoder.rs
+++ b/crates/compression-codecs/src/zstd/decoder.rs
@@ -54,9 +54,7 @@ impl ZstdDecoder {
         output: &mut WriteBuffer<'_>,
         f: fn(&mut Decoder<'static>, &mut zstd_safe::OutBuffer<'_, [u8]>) -> io::Result<usize>,
     ) -> io::Result<bool> {
-        output.initialize_unwritten();
-
-        let mut out_buf = zstd_safe::OutBuffer::around(output.unwritten_initialized_mut());
+        let mut out_buf = zstd_safe::OutBuffer::around(output.initialize_unwritten());
         let res = f(self.decoder.get_mut(), &mut out_buf);
         let len = out_buf.as_slice().len();
         output.advance(len);
@@ -77,12 +75,10 @@ impl DecodeV2 for ZstdDecoder {
         input: &mut PartialBuffer<&[u8]>,
         output: &mut WriteBuffer<'_>,
     ) -> Result<bool> {
-        output.initialize_unwritten();
-
         let status = self
             .decoder
             .get_mut()
-            .run_on_buffers(input.unwritten(), output.unwritten_initialized_mut())?;
+            .run_on_buffers(input.unwritten(), output.initialize_unwritten())?;
         input.advance(status.bytes_read);
         output.advance(status.bytes_written);
 

--- a/crates/compression-codecs/src/zstd/encoder.rs
+++ b/crates/compression-codecs/src/zstd/encoder.rs
@@ -42,9 +42,7 @@ impl ZstdEncoder {
         output: &mut WriteBuffer<'_>,
         f: fn(&mut Encoder<'static>, &mut zstd_safe::OutBuffer<'_, [u8]>) -> io::Result<usize>,
     ) -> io::Result<bool> {
-        output.initialize_unwritten();
-
-        let mut out_buf = zstd_safe::OutBuffer::around(output.unwritten_initialized_mut());
+        let mut out_buf = zstd_safe::OutBuffer::around(output.initialize_unwritten());
         let res = f(self.encoder.get_mut(), &mut out_buf);
         let len = out_buf.as_slice().len();
         output.advance(len);
@@ -59,12 +57,10 @@ impl EncodeV2 for ZstdEncoder {
         input: &mut PartialBuffer<&[u8]>,
         output: &mut WriteBuffer<'_>,
     ) -> Result<()> {
-        output.initialize_unwritten();
-
         let status = self
             .encoder
             .get_mut()
-            .run_on_buffers(input.unwritten(), output.unwritten_initialized_mut())?;
+            .run_on_buffers(input.unwritten(), output.initialize_unwritten())?;
         input.advance(status.bytes_read);
         output.advance(status.bytes_written);
         Ok(())

--- a/crates/compression-core/src/util.rs
+++ b/crates/compression-core/src/util.rs
@@ -108,10 +108,8 @@ impl<'a> WriteBuffer<'a> {
     }
 
     /// Initialize all uninitialized, unwritten part to initialized, unwritten part
-    pub fn initialize_unwritten(&mut self) {}
-
-    /// Return initialized but unwritten part.
-    pub fn unwritten_initialized_mut(&mut self) -> &mut [u8] {
+    /// Return all unwritten part
+    pub fn initialize_unwritten(&mut self) -> &mut [u8] {
         &mut self.buffer[self.index..]
     }
 
@@ -129,11 +127,11 @@ impl<'a> WriteBuffer<'a> {
 
     pub fn copy_unwritten_from<C: AsRef<[u8]>>(&mut self, other: &mut PartialBuffer<C>) -> usize {
         let len = self
-            .unwritten_initialized_mut()
+            .initialize_unwritten()
             .len()
             .min(other.unwritten().len());
 
-        self.unwritten_initialized_mut()[..len].copy_from_slice(&other.unwritten()[..len]);
+        self.initialize_unwritten()[..len].copy_from_slice(&other.unwritten()[..len]);
 
         self.advance(len);
         other.advance(len);


### PR DESCRIPTION
Mirror `tokio::io::ReadBuf`.

Also ensure `{in, out}put` is always advanced on error