### PR TITLE
Refactor `bufread::decoder`: Extract poll ready check

### DIFF
--- a/crates/async-compression/src/futures/bufread/generic/decoder.rs
+++ b/crates/async-compression/src/futures/bufread/generic/decoder.rs
@@ -23,10 +23,8 @@ impl<R: AsyncBufRead, D: DecodeV2> AsyncRead for Decoder<R, D> {
         }
 
         let mut output = WriteBuffer::new_initialized(buf);
-        match self.do_poll_read(cx, &mut output)? {
-            Poll::Pending if output.written().is_empty() => Poll::Pending,
-            _ => Poll::Ready(Ok(output.written_len())),
-        }
+        self.do_poll_read(cx, &mut output)
+            .map_ok(|()| output.written_len())
     }
 }
 

--- a/crates/async-compression/src/futures/bufread/generic/encoder.rs
+++ b/crates/async-compression/src/futures/bufread/generic/encoder.rs
@@ -23,10 +23,8 @@ impl<R: AsyncBufRead, E: EncodeV2> AsyncRead for Encoder<R, E> {
         }
 
         let mut output = WriteBuffer::new_initialized(buf);
-        match self.do_poll_read(cx, &mut output)? {
-            Poll::Pending if output.written().is_empty() => Poll::Pending,
-            _ => Poll::Ready(Ok(output.written_len())),
-        }
+        self.do_poll_read(cx, &mut output)
+            .map_ok(|()| output.written_len())
     }
 }
 

--- a/crates/async-compression/src/tokio/bufread/generic/mod.rs
+++ b/crates/async-compression/src/tokio/bufread/generic/mod.rs
@@ -30,8 +30,5 @@ fn poll_read(
     unsafe { buf.assume_init(initialized) };
     buf.advance(written);
 
-    match res? {
-        Poll::Pending if written == 0 => Poll::Pending,
-        _ => Poll::Ready(Ok(())),
-    }
+    res
 }


### PR DESCRIPTION
Move the check into the generic implementation,
instead of repeating