### PR TITLE
Refactor: Simplify `AsyncBufWrite`

### DIFF
--- a/crates/async-compression/src/generic/write/buf_write.rs
+++ b/crates/async-compression/src/generic/write/buf_write.rs
@@ -1,3 +1,4 @@
+use super::Buffer;
 use std::{
     io,
     pin::Pin,
@@ -16,17 +17,5 @@ pub(crate) trait AsyncBufWrite {
     fn poll_partial_flush_buf(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&mut [u8]>>;
-
-    /// Tells this buffer that `amt` bytes have been written to its buffer, so they should be
-    /// written out to the underlying IO when possible.
-    ///
-    /// This function is a lower-level call. It needs to be paired with the `poll_flush_buf` method to
-    /// function properly. This function does not perform any I/O, it simply informs this object
-    /// that some amount of its buffer, returned from `poll_flush_buf`, has been written to and should
-    /// be sent. As such, this function may do odd things if `poll_flush_buf` isn't
-    /// called before calling it.
-    ///
-    /// The `amt` must be `<=` the number of bytes in the buffer returned by `poll_flush_buf`.
-    fn produce(self: Pin<&mut Self>, amt: usize);
+    ) -> Poll<io::Result<Buffer<'_>>>;
 }


### PR DESCRIPTION
Change `poll_partial_flush_buf` to return a `Buffer<'_>`, which include a public `WriteBuffer` field, and a `Drop` impl so that it automatically advances the underlying `BufWriter`.

Rm the `produce` method as we no longer need it