### PR TITLE
Optimize GzipDecoder

### DIFF
--- a/crates/compression-codecs/src/gzip/decoder.rs
+++ b/crates/compression-codecs/src/gzip/decoder.rs
@@ -82,7 +82,7 @@ impl GzipDecoder {
                     let done = res?;
 
                     if done {
-                        self.state = State::Footer([0; 8]);
+                        self.state = State::Footer([0; 8].into());
                     }
                 }
 


### PR DESCRIPTION
Related #397 

 - no heap allocation for footer which has fixed 8-byte size
 - do not store unused header
 - reset CrC instead of reassigning a new one
 - optimize check_crc: rm unnecessary size check