### PR TITLE
fix: encoder not flushing data

### DIFF
--- a/crates/async-compression/src/generic/bufread/encoder.rs
+++ b/crates/async-compression/src/generic/bufread/encoder.rs
@@ -58,7 +58,7 @@ impl Encoder {
 
                             read += input.written().len();
 
-                            // Poll for more data
+                            self.state = State::Encoding(read);
                             break;
                         }
                     }

--- a/crates/async-compression/src/tokio/bufread/generic/mod.rs
+++ b/crates/async-compression/src/tokio/bufread/generic/mod.rs
@@ -30,5 +30,9 @@ fn poll_read(
     unsafe { buf.assume_init(initialized) };
     buf.advance(written);
 
-    res
+    match res {
+        Poll::Pending if written == 0 => Poll::Pending,
+        Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+        _ => Poll::Ready(Ok(())),
+    }
 }


### PR DESCRIPTION
hi, thank you for your work on this library!

after upgrading async-compression, our custom protocol stopped working i.e. receiving responses like for eg, ACKs would get stuck and never reach the client, this happened on release 0.4.33 so i ran git bisect:

good: `b79f66d40697ab7dadf791a416ab2ba15cccc3a3`
bad: `2aa1b5f8122618004b9bbab6dc679bafca616ff2`

and `6c0835eb5dd26cb6176acd0455437be13fdaadac` being the one where this problem happens (https://github.com/Nullus157/async-compression/pull/402)

i went over the changes and it seemed like the loop exited before setting the counter was set so i set:

```
self.state = State::Encoding(read)
```
and it seemed to work on that commit with my sample code, but then again broken when i applied this change on main, so i ran git bisect again etc comparing against my working version and saw some behavior was changed changing AsyncRead impl back to returning Ready whenever data was written to buffer worked

idk how correct this is, but wanted to try to fix this as it did break things with Tower's compression layer enabled for us when we upgraded deps to move from 0.4.32 -> 0.4.36

happy to work on this further and improve this. appreciate any feedback to fix this (: 