### PR TITLE
chore: Switch futures_core::ready to standard library api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [workspace.dependencies]
 compression-codecs = { version = "0.4.35", path = "crates/compression-codecs" }
 compression-core = { version = "0.4.31", path = "crates/compression-core" }
-futures-core = { version = "0.3", default-features = false }
 pin-project-lite = "0.2"
 
 [workspace.lints.rust]

--- a/crates/async-compression/Cargo.toml
+++ b/crates/async-compression/Cargo.toml
@@ -49,7 +49,6 @@ zstdmt = ["compression-codecs/zstdmt", "zstd"]
 
 [dependencies]
 # core dependencies
-futures-core.workspace = true
 pin-project-lite.workspace = true
 compression-codecs.workspace = true
 compression-core.workspace = true

--- a/crates/async-compression/src/generic/bufread/decoder.rs
+++ b/crates/async-compression/src/generic/bufread/decoder.rs
@@ -114,9 +114,8 @@ macro_rules! impl_decoder {
     () => {
         use crate::generic::bufread::Decoder as GenericDecoder;
 
-        use std::ops::ControlFlow;
+        use std::{ops::ControlFlow, task::ready};
 
-        use futures_core::ready;
         use pin_project_lite::pin_project;
 
         pin_project! {

--- a/crates/async-compression/src/generic/bufread/encoder.rs
+++ b/crates/async-compression/src/generic/bufread/encoder.rs
@@ -101,9 +101,8 @@ macro_rules! impl_encoder {
     () => {
         use crate::generic::bufread::Encoder as GenericEncoder;
 
-        use std::ops::ControlFlow;
+        use std::{ops::ControlFlow, task::ready};
 
-        use futures_core::ready;
         use pin_project_lite::pin_project;
 
         pin_project! {

--- a/crates/async-compression/src/generic/write/buf_writer.rs
+++ b/crates/async-compression/src/generic/write/buf_writer.rs
@@ -4,11 +4,10 @@
 
 use super::AsyncBufWrite;
 use compression_core::util::WriteBuffer;
-use futures_core::ready;
 use std::{
     fmt, io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 const DEFAULT_BUF_SIZE: usize = 8192;
@@ -168,8 +167,8 @@ impl Drop for Buffer<'_> {
 macro_rules! impl_buf_writer {
     ($poll_close: tt) => {
         use crate::generic::write::{AsyncBufWrite, BufWriter as GenericBufWriter, Buffer};
-        use futures_core::ready;
         use pin_project_lite::pin_project;
+        use std::task::ready;
 
         pin_project! {
             #[derive(Debug)]

--- a/crates/async-compression/src/generic/write/decoder.rs
+++ b/crates/async-compression/src/generic/write/decoder.rs
@@ -3,11 +3,10 @@ use crate::{
     core::util::{PartialBuffer, WriteBuffer},
     generic::write::AsyncBufWrite,
 };
-use futures_core::ready;
 use std::{
     io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 #[derive(Debug)]
@@ -60,7 +59,7 @@ impl Decoder {
                 }
 
                 State::Done => {
-                    return Poll::Ready(Err(io::Error::other("Write after end of stream")))
+                    return Poll::Ready(Err(io::Error::other("Write after end of stream")));
                 }
             };
 
@@ -144,8 +143,8 @@ macro_rules! impl_decoder {
         use crate::{
             codecs::DecodeV2, core::util::PartialBuffer, generic::write::Decoder as GenericDecoder,
         };
-        use futures_core::ready;
         use pin_project_lite::pin_project;
+        use std::task::ready;
 
         pin_project! {
             #[derive(Debug)]

--- a/crates/async-compression/src/generic/write/encoder.rs
+++ b/crates/async-compression/src/generic/write/encoder.rs
@@ -3,11 +3,10 @@ use crate::{
     core::util::{PartialBuffer, WriteBuffer},
     generic::write::AsyncBufWrite,
 };
-use futures_core::ready;
 use std::{
     io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 #[derive(Debug)]
@@ -49,7 +48,7 @@ impl Encoder {
                 }
 
                 State::Finishing | State::Done => {
-                    break Poll::Ready(Err(io::Error::other("Write after close")))
+                    break Poll::Ready(Err(io::Error::other("Write after close")));
                 }
             };
 
@@ -92,7 +91,7 @@ impl Encoder {
                 State::Encoding => encoder.flush(output)?,
 
                 State::Finishing | State::Done => {
-                    break Poll::Ready(Err(io::Error::other("Flush after close")))
+                    break Poll::Ready(Err(io::Error::other("Flush after close")));
                 }
             };
 
@@ -134,8 +133,8 @@ impl Encoder {
 macro_rules! impl_encoder {
     ($poll_close: tt) => {
         use crate::{codecs::EncodeV2, generic::write::Encoder as GenericEncoder};
-        use futures_core::ready;
         use pin_project_lite::pin_project;
+        use std::task::ready;
 
         pin_project! {
             #[derive(Debug)]


### PR DESCRIPTION
`std::task::ready` could be used instead of `futures_core::ready`.