### PR TITLE
ci: Use cargo-deny graph option

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Ignore dev-dependencies
-      run: sed -i 's/\[dev-dependencies\]/[workaround-avoid-dev-deps]/g' Cargo.toml
     - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check bans licenses sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,7 @@
+[graph]
+all-features = true
+exclude-dev = true
+
 [advisories]
 ignore = [
 ]
@@ -7,14 +11,10 @@ allow = [
   "MIT",
   "Apache-2.0",
   "BSD-3-Clause",
-  "Unicode-3.0",
   "bzip2-1.0.6",
 ]
 
 [bans]
 multiple-versions = "warn"
 skip = [
-]
-skip-tree = [
-  { name = "proptest", version = "1.0" },
 ]


### PR DESCRIPTION
`cargo-deny`'s graph option could be used to ignore `dev-dependencies`.