### PR TITLE
Fix decoding of empty response streams.

### DIFF
--- a/crates/async-compression/Cargo.toml
+++ b/crates/async-compression/Cargo.toml
@@ -139,6 +139,10 @@ required-features = ["zlib", "tokio"]
 name = "zstd_gzip"
 required-features = ["zstd", "gzip", "tokio"]
 
+[[test]]
+name = "empty_stream"
+required-features = ["zstd", "tokio"]
+
 [[example]]
 name = "lzma_filters"
 required-features = ["xz", "tokio"]

--- a/crates/async-compression/tests/empty_stream.rs
+++ b/crates/async-compression/tests/empty_stream.rs
@@ -1,0 +1,19 @@
+//! Test that bufread decoders handle empty input streams (immediate EOF).
+
+#[macro_use]
+mod utils;
+
+#[tokio::test]
+async fn zstd_empty_stream() {
+    use async_compression::tokio::bufread::ZstdDecoder;
+    use std::io::Cursor;
+    use tokio::io::AsyncReadExt;
+
+    let empty: &[u8] = &[];
+    let mut decoder = ZstdDecoder::new(Cursor::new(empty));
+    let mut output = Vec::new();
+    let result = decoder.read_to_end(&mut output).await;
+    // Empty input should return Ok(0), not error with "zstd stream did not finish"
+    assert!(result.is_ok(), "empty stream failed: {:?}", result);
+    assert!(output.is_empty());
+}


### PR DESCRIPTION
Previously we were returning "zstd stream did not finish", but now we notice we got no data and transition directly to the done state.