### PR TITLE
Include license files in published crates

### DIFF
--- a/crates/async-compression/LICENSE-APACHE
+++ b/crates/async-compression/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/async-compression/LICENSE-MIT
+++ b/crates/async-compression/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/compression-codecs/LICENSE-APACHE
+++ b/crates/compression-codecs/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/compression-codecs/LICENSE-MIT
+++ b/crates/compression-codecs/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/compression-core/LICENSE-APACHE
+++ b/crates/compression-core/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/compression-core/LICENSE-MIT
+++ b/crates/compression-core/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Hi, this PR symlinks the license files so they're included in published crates (which is nice for tools like [`cargo vendor`](https://doc.rust-lang.org/cargo/commands/cargo-vendor.html)).