### PR TITLE
Fix hang when decoding a corrupt subsequent zstd frame

### DIFF
--- a/crates/async-compression/src/generic/bufread/decoder.rs
+++ b/crates/async-compression/src/generic/bufread/decoder.rs
@@ -81,9 +81,8 @@ impl Decoder {
                                     }
                                 }
 
-                                // The decode stage might consume all the input,
-                                // the next stage might need to poll again if it's empty.
-                                first = true;
+                                // Poll again only if the decode stage consumed all the input.
+                                first = input.unwritten().is_empty();
                                 State::Next
                             } else {
                                 State::Done

--- a/crates/async-compression/tests/utils/test_cases.rs
+++ b/crates/async-compression/tests/utils/test_cases.rs
@@ -234,6 +234,24 @@ macro_rules! io_test_cases {
 
                     #[test]
                     #[ntest::timeout(1000)]
+                    fn corrupt_second_member() {
+                        let first = sync::compress(&[1, 2, 3, 4, 5, 6]);
+                        let mut second = sync::compress(&[0; 2048]);
+                        let corrupt = second.len() - 2;
+                        second[corrupt] ^= 0xff;
+                        let compressed = [first, second].join(&[][..]);
+
+                        let input = InputStream::new(vec![compressed]);
+                        let result = std::panic::catch_unwind(|| {
+                            let mut decoder = bufread::Decoder::new(bufread::from(&input));
+                            decoder.multiple_members(true);
+                            read::to_vec(decoder)
+                        });
+                        assert!(result.is_err());
+                    }
+
+                    #[test]
+                    #[ntest::timeout(1000)]
                     fn truncated() {
                         let compressed = sync::compress(&[1, 2, 3, 4, 5, 6]);
 

--- a/crates/async-compression/tests/zstd.rs
+++ b/crates/async-compression/tests/zstd.rs
@@ -2,3 +2,24 @@
 mod utils;
 
 test_cases!(zstd);
+
+#[cfg(feature = "tokio")]
+#[test]
+#[ntest::timeout(1000)]
+fn bufread_multiple_members_with_corrupt_second_frame() {
+    use async_compression::tokio::bufread::ZstdDecoder;
+    use tokio::io::{sink, BufReader};
+    use utils::algos::zstd::sync;
+
+    let first = sync::compress(&[1, 2, 3, 4, 5, 6]);
+    let mut second = sync::compress(&[0; 2048]);
+    let corrupt = second.len() - 2;
+    second[corrupt] ^= 0xff;
+    let compressed = [first, second].join(&[][..]);
+
+    let mut decoder = ZstdDecoder::new(BufReader::new(compressed.as_slice()));
+    decoder.multiple_members(true);
+
+    let result = futures::executor::block_on(tokio::io::copy(&mut decoder, &mut sink()));
+    assert!(result.is_err());
+}

--- a/crates/async-compression/tests/zstd.rs
+++ b/crates/async-compression/tests/zstd.rs
@@ -2,24 +2,3 @@
 mod utils;
 
 test_cases!(zstd);
-
-#[cfg(feature = "tokio")]
-#[test]
-#[ntest::timeout(1000)]
-fn bufread_multiple_members_with_corrupt_second_frame() {
-    use async_compression::tokio::bufread::ZstdDecoder;
-    use tokio::io::{sink, BufReader};
-    use utils::algos::zstd::sync;
-
-    let first = sync::compress(&[1, 2, 3, 4, 5, 6]);
-    let mut second = sync::compress(&[0; 2048]);
-    let corrupt = second.len() - 2;
-    second[corrupt] ^= 0xff;
-    let compressed = [first, second].join(&[][..]);
-
-    let mut decoder = ZstdDecoder::new(BufReader::new(compressed.as_slice()));
-    decoder.multiple_members(true);
-
-    let result = futures::executor::block_on(tokio::io::copy(&mut decoder, &mut sink()));
-    assert!(result.is_err());
-}


### PR DESCRIPTION
Fix an infinite loop when decoding concatenated zstd frames with `multiple_members(true)` and a later frame is corrupt.

After completing a frame, the bufread decoder incorrectly treats the next decode as an empty-input poll even when input remains buffered, suppressing the corruption error and allowing the decoder to spin without making progress. Only request another poll when the current buffer is exhausted, ensuring errors from subsequent frames are propagated.
