### PR TITLE
chore(deps): update zstd requirement from 0.13 to 0.14

### DIFF
--- a/crates/async-compression/Cargo.toml
+++ b/crates/async-compression/Cargo.toml
@@ -78,10 +78,10 @@ tokio-util = { version = "0.7", default-features = false, features = ["io"] }
 brotli = "8"
 bzip2 = "0.6"
 flate2 = "1.0.13"
-libzstd = { package = "zstd", version = "0.13.1", default-features = false }
+libzstd = { package = "zstd", version = "0.14.0", default-features = false }
 lz4 = "1.28.1"
 liblzma = "0.4.2"
-zstd-safe = { version = "7", default-features = false }
+zstd-safe = { version = "8", default-features = false }
 deflate64 = "0.1.5"
 
 [lints]

--- a/crates/compression-codecs/Cargo.toml
+++ b/crates/compression-codecs/Cargo.toml
@@ -51,11 +51,11 @@ brotli = { version = "8", optional = true }
 bzip2 = { version = "0.6.1", optional = true }
 deflate64 = { version = "0.1.10", optional = true }
 flate2 = { version = "1.1.4", optional = true }
-libzstd = { package = "zstd", version = "0.13.1", optional = true, default-features = false }
+libzstd = { package = "zstd", version = "0.14.0", optional = true, default-features = false }
 lz4 = { version = "1.28.1", optional = true }
 liblzma = { version = "0.4.5", optional = true }
 memchr = { version = "2", optional = true }
-zstd-safe = { version = "7", optional = true, default-features = false }
+zstd-safe = { version = "8", optional = true, default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Bumps the `zstd` dependency from `0.13.1` to `0.14.0` (pulls in `zstd-safe` 8.0.0 / `zstd-sys` 2.1.0).

The codecs use the `stream::raw` API (streaming `Encoder`/`Decoder` with `InBuffer`/`OutBuffer`) and `zstd-safe`'s `get_error_name` and `find_frame_compressed_size`, none of which changed in 0.14.0/8.0.0, so this is a pure version bump with no code changes.

Also worth noting: `zstd-safe` 8.0.0 refuses to reuse a context that failed mid-stream (per the zstd docs it may be left in an undefined state, so that was UB before), and `zstd-sys` 2.1.0 no longer needs `libclang` by default. The crate stack moved from MIT to BSD-3-Clause (still permissive, already allowed in deny.toml).