### PR TITLE
Return UnexpectedEof when deflate64 does not progress

### DIFF
--- a/crates/async-compression/Cargo.toml
+++ b/crates/async-compression/Cargo.toml
@@ -100,6 +100,10 @@ name = "deflate"
 required-features = ["deflate"]
 
 [[test]]
+name = "deflate64"
+required-features = ["deflate64", "tokio"]
+
+[[test]]
 name = "gzip"
 required-features = ["gzip"]
 

--- a/crates/async-compression/src/generic/bufread/decoder.rs
+++ b/crates/async-compression/src/generic/bufread/decoder.rs
@@ -69,7 +69,18 @@ impl Decoder {
                 }
 
                 State::Flushing => {
-                    match decoder.finish(output) {
+                    let before = output.written_len();
+                    let result = decoder.finish(output).and_then(|finished| {
+                        if !finished
+                            && output.written_len() == before
+                            && !output.has_no_spare_space()
+                        {
+                            Err(std::io::ErrorKind::UnexpectedEof.into())
+                        } else {
+                            Ok(finished)
+                        }
+                    });
+                    match result {
                         Ok(true) => {
                             if self.multiple_members {
                                 if let Err(err) = decoder.reinit() {

--- a/crates/async-compression/src/generic/write/decoder.rs
+++ b/crates/async-compression/src/generic/write/decoder.rs
@@ -109,8 +109,11 @@ impl Decoder {
                 }
 
                 State::Finishing => {
+                    let before = output.written_len();
                     if decoder.finish(output)? {
                         (State::Done, false)
+                    } else if output.written_len() == before && !output.has_no_spare_space() {
+                        return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()));
                     } else {
                         (State::Finishing, false)
                     }

--- a/crates/async-compression/tests/deflate64.rs
+++ b/crates/async-compression/tests/deflate64.rs
@@ -1,0 +1,19 @@
+use async_compression::tokio::{bufread, write};
+use std::io::ErrorKind;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tokio::test]
+async fn truncated_stream_returns_unexpected_eof_on_read_and_shutdown() {
+    let input = tokio::io::BufReader::new(&[0x00][..]);
+    let mut decoder = bufread::Deflate64Decoder::new(input);
+    let mut output = Vec::new();
+
+    let error = decoder.read_to_end(&mut output).await.unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
+
+    let mut decoder = write::Deflate64Decoder::new(Vec::new());
+    decoder.write_all(&[0x00]).await.unwrap();
+
+    let error = decoder.shutdown().await.unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
+}

--- a/crates/compression-codecs/src/deflate64/decoder.rs
+++ b/crates/compression-codecs/src/deflate64/decoder.rs
@@ -72,6 +72,12 @@ impl DecodeV2 for Deflate64Decoder {
     }
 
     fn finish(&mut self, output: &mut WriteBuffer<'_>) -> Result<bool> {
-        self.decode(&mut PartialBuffer::new(&[]), output)
+        let before = output.written_len();
+        let finished = self.decode(&mut PartialBuffer::new(&[]), output)?;
+        if !finished && output.written_len() == before && !output.has_no_spare_space() {
+            Err(ErrorKind::UnexpectedEof.into())
+        } else {
+            Ok(finished)
+        }
     }
 }


### PR DESCRIPTION
This is technically a denial-of-service vector, but I'm opening it publicly because I think it's _very_ niche (Deflate64 is itself niche).

Deflate64 uses a NUL byte to indicate the start of a stored (i.e. non-compressed) block. However, if no data actually follows that marker, the implementation (on the async adapter side) would previously spin forever since `finish` would only signal "not finished" rather than a premature EOF.

The fix is to have the decompression layer check for actual read progress, and then return UnexpectedEof rather than a finished/not-finished boolean state when no more progress can be made.